### PR TITLE
add -fstack-usage to build flags

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,6 +5,9 @@
 # http://docs.platformio.org/en/latest/projectconf.html
 #
 
+[common]
+build_flags = -fstack-usage
+
 [env:host]
 platform = teensy
 framework = arduino
@@ -13,10 +16,11 @@ board = teensy31
 lib_install = 28, 129
 src_filter = +<host/*>
 lib_ignore = ESPAsyncTCP
+build_flags = ${common.build_flags}
 # uncomment to get seatalk support
-#build_flags = -DSERIAL_9BIT_SUPPORT -DSEATALK
+#build_flags = ${common.build_flags} -DSERIAL_9BIT_SUPPORT -DSEATALK
 # or uncomment this to send all debugging to NMEA2 instead of USB
-#build_flags = -DDebugSerial=Serial3
+#build_flags = ${common.build_flags} -DDebugSerial=Serial3
 
 # This configuration builds a very simple firmware for the host that allows to upload
 # a firmware to the ESP8266 module.
@@ -27,7 +31,7 @@ board = teensy31
 src_filter = +<program-esp/*>
 lib_ignore = ESPAsyncTCP
 # log everything to Nmea2 output so we can see something
-build_flags = -DDebugSerial=Serial3
+build_flags = ${common.build_flags} -DDebugSerial=Serial3
 
 [env:esp]
 src_filter = +<esp/*>
@@ -35,9 +39,11 @@ platform = espressif8266
 framework = arduino
 board = esp_wroom_02
 extra_script = esp_extra.py
+build_flags = ${common.build_flags}
 
 [env:mfg]
 platform = teensy
 framework = arduino
 board = teensy31
 src_filter = +<mfg/*>
+build_flags = ${common.build_flags}


### PR DESCRIPTION
Introduces a new section `[common]` in `platformio.ini` to define common build flags that enable compilation with [`-fstack-usage`](https://gcc.gnu.org/onlinedocs/gcc-4.3.6/gnat_ugn_unw/Static-Stack-Usage-Analysis.html#Static-Stack-Usage-Analysis).

This enables external tools such as [puncover](https://github.com/HBehrens/puncover) to provide additional information about kbox firmware (see screenshot)
<img width="961" alt="screen shot 2017-03-30 at 22 19 51" src="https://cloud.githubusercontent.com/assets/486904/24537544/b7a4ff0e-1597-11e7-9720-ce499f6ee035.png">

I am not sure, how to verify that this won't break any existing build. Ran `platformio run` and got
```
Environment host       	[SUCCESS]
Environment program-esp	[SUCCESS]
Environment esp        	[SUCCESS]
Environment mfg        	[SUCCESS]
```
and will otherwise trust the CI system ;)