### PR TITLE
Fix IMU units discrepancies

### DIFF
--- a/lib/KBox/src/KMessageNMEAVisitor.cpp
+++ b/lib/KBox/src/KMessageNMEAVisitor.cpp
@@ -63,20 +63,23 @@ void KMessageNMEAVisitor::visit(const NMEA2000Message &n2km) {
   free(s);
 }
 
+
+inline static double RadToDeg(double v) { return v*180.0/3.1415926535897932384626433832795; }
+
 void KMessageNMEAVisitor::visit(const IMUMessage &imu) {
   NMEASentenceBuilder sb("II", "XDR", 16);
   sb.setField(1, "A");
-  sb.setField(2, imu.getYaw(), 1);
+  sb.setField(2, RadToDeg(imu.getYaw()), 1);
   sb.setField(3, "D");
   sb.setField(4, "Yaw");
 
   sb.setField(5, "A");
-  sb.setField(6, imu.getPitch(), 1);
+  sb.setField(6, RadToDeg(imu.getPitch()), 1);
   sb.setField(7, "D");
   sb.setField(8, "Pitch");
 
   sb.setField(9, "A");
-  sb.setField(10, imu.getRoll(), 1);
+  sb.setField(10, RadToDeg(imu.getRoll()), 1);
   sb.setField(11, "D");
   sb.setField(12, "Roll");
 
@@ -88,7 +91,7 @@ void KMessageNMEAVisitor::visit(const IMUMessage &imu) {
   nmeaContent += sb.toNMEA() + "\r\n";
 
   NMEASentenceBuilder sb2("II", "HDM", 2);
-  sb2.setField(1, imu.getCourse());
+  sb2.setField(1, RadToDeg(imu.getCourse()));
   sb2.setField(2, "M");
 
   nmeaContent += sb2.toNMEA() + "\r\n";

--- a/lib/KBox/src/tasks/IMUTask.cpp
+++ b/lib/KBox/src/tasks/IMUTask.cpp
@@ -34,6 +34,8 @@ void IMUTask::setup() {
   }
 }
 
+static inline double DegToRad(double v) { return v/180.0*3.1415926535897932384626433832795; };
+
 void IMUTask::loop() {
   //uint8_t system_status, self_test_status, system_error;
   //bno055.getSystemStatus(&system_status, &self_test_status, &system_error);
@@ -47,7 +49,15 @@ void IMUTask::loop() {
     eulerAngles = bno055.getVector(Adafruit_BNO055::VECTOR_EULER);
     //DEBUG("Vector Euler x=%f y=%f z=%f", eulerAngles.x(), eulerAngles.y(), eulerAngles.z());
     //DEBUG("Course: %.0f MAG  Pitch: %.1f  Heel: %.1f", eulerAngles.x(), eulerAngles.y(), eulerAngles.z());
-    IMUMessage m(sysCalib, eulerAngles.x(), /* yaw?*/ 0, eulerAngles.y(), eulerAngles.z());
+
+    // Assuming the KBox is mounted on the PORT Hull, right side of KBox towards
+    // bow of the boat.
+    double course = fmod(eulerAngles.x() + 270, 360);
+    double yaw = 0;
+    double pitch = eulerAngles.y();
+    double roll = eulerAngles.z();
+
+    IMUMessage m(sysCalib, DegToRad(course), /* yaw?*/ 0, DegToRad(pitch), DegToRad(roll));
     sendMessage(m);
   }
   

--- a/lib/KBox/test/KMessageNMEAVisitorTest.cpp
+++ b/lib/KBox/test/KMessageNMEAVisitorTest.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Visiting a NMEA0183 sentence message") {
 }
 
 TEST_CASE("Visiting a IMU object") {
-  IMUMessage m(3, 232.423, 4.19, 10.122331, 29.028);
+  IMUMessage m(3, DegToRad(232.423), DegToRad(4.19), DegToRad(10.122331), DegToRad(29.028));
 
   KMessageNMEAVisitor v;
   m.accept(v);


### PR DESCRIPTION
 - IMU sends data in degrees (code assumed radians)
 - NMEA2000 expects radians
 - NMEA expects degrees
 - We should always store in radians internally

This fixes #46.