### PR TITLE
Fix units in Pressure messages and change PGN used

### DIFF
--- a/src/common/signalk/SKNMEA2000Visitor.cpp
+++ b/src/common/signalk/SKNMEA2000Visitor.cpp
@@ -53,7 +53,13 @@ void SKNMEA2000Visitor::visitSKElectricalBatteriesVoltage(const SKUpdate& u, con
 
 void SKNMEA2000Visitor::visitSKEnvironmentOutsidePressure(const SKUpdate& u, const SKPath &p, const SKValue &v) {
   tN2kMsg *msg = new tN2kMsg();
-  SetN2kPressure(*msg, /* sid */ 0, /* source */ 0, N2kps_Atmospheric, v.getNumberValue());
+
+  // PGN 130310 seems to be better supported
+  SetN2kOutsideEnvironmentalParameters(*msg, 0, N2kDoubleNA, N2kDoubleNA, v.getNumberValue());
+
+  // PGN 130314 is more specific to pressure but not supported by Raymarine i70
+  //SetN2kPressure(*msg, /* sid */ 0, /* source */ 0, N2kps_Atmospheric, v.getNumberValue());
+
   _messages.add(msg);
 }
 

--- a/src/host/services/BarometerService.cpp
+++ b/src/host/services/BarometerService.cpp
@@ -42,10 +42,10 @@ void BarometerService::fetchValues() {
   temperature = bmp280.readTemperature();
   pressure = bmp280.readPressure();
 
-  DEBUG("Read temperature=%.2f C and pressure=%.1f hPa", temperature, pressure/100);
+  DEBUG("Read temperature=%.2f C and pressure=%.1f Pa", temperature, 100);
 
   SKUpdateStatic<1> update;
-  update.setEnvironmentOutsidePressure(pressure / 100);
+  update.setEnvironmentOutsidePressure(pressure);
   _skHub.publish(update);
 }
 


### PR DESCRIPTION
 - Storing data in Pascal, sending in Pascal
 - Using PGN 130310 which seems to be better supported than PGN 130314

closes #44