### PR TITLE
NMEA sentence length is 82 bytes of data + terminating 0

### DIFF
--- a/src/host/services/NMEAService.h
+++ b/src/host/services/NMEAService.h
@@ -31,7 +31,7 @@
 #include "common/signalk/SKHub.h"
 
 // Defined by the NMEA Standard
-#define MAX_NMEA_SENTENCE_LENGTH 82
+#define MAX_NMEA_SENTENCE_LENGTH 83
 
 class HardwareSerial;
 


### PR DESCRIPTION
Closes #58 - thanks @ronzeiller