### PR TITLE
IMUMonitorPage with filtered values for HDG, Heel, Pitch

### DIFF
--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -28,6 +28,7 @@
 #include "common/signalk/SKHub.h"
 #include "host/drivers/ILI9341GC.h"
 #include "host/pages/BatteryMonitorPage.h"
+#include "host/pages/IMUMonitorPage.h"
 #include "host/pages/StatsPage.h"
 #include "host/services/MFD.h"
 #include "host/services/ADCService.h"
@@ -102,6 +103,9 @@ void setup() {
 
   BatteryMonitorPage *batPage = new BatteryMonitorPage(skHub);
   mfd.addPage(batPage);
+  
+  IMUMonitorPage *imuPage = new IMUMonitorPage(skHub);
+  mfd.addPage(imuPage);
 
   StatsPage *statsPage = new StatsPage();
   statsPage->setSDCardTask(sdcardTask);

--- a/src/host/pages/IMUMonitorPage.cpp
+++ b/src/host/pages/IMUMonitorPage.cpp
@@ -1,0 +1,133 @@
+/*
+  * Project:  KBox
+  * Purpose:  IMU Monitor Page for HDG, Heel & Pitch (+ Cal planned)
+  * Author:   (c) Ronnie Zeiller, 2017
+  * KBox:     (c) 2017 Thomas Sarlandie thomas@sarlandie.net
+
+  The MIT License
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#include <stdio.h>
+#include "common/signalk/SKUpdate.h"
+#include "IMUMonitorPage.h"
+#include <KBoxLogging.h>
+#include "signalk/SKUnits.h"
+#include "services/IMUService.h"
+#include "common/signalk/SKUpdateStatic.h"
+#include "common/signalk/SKUnits.h"
+
+
+IMUMonitorPage::IMUMonitorPage(SKHub& hub) {
+  _IMU_HDGFiltered    = 361;
+  _IMU_PitchFiltered  = 181;
+  _IMU_HeelFiltered   = 181;
+
+  // Damping values 1.....100 --> 0.5 no filter ......0.005 max filter
+  // for higher frequencies even more
+  // TODO: make KBox setting for damping values 1.......100
+
+  // auto damping factored by the IMUServiceInterval which is
+  // probably between 50 and 100 (20 - 10 Hz)
+  // TODO: set and get IMUServiceInterval for automatic modus -> #define IMUServiceInterval ??
+
+  _dampingHdg = _IMUServiceInterval / 1400.000; // 0.05
+  if (_dampingHdg>0.5) _dampingHdg=0.5;
+
+
+  // Heel and Pitch need smaller damping
+  _dampingHeelPitch = _IMUServiceInterval / 700.000; // 0.1 .... 0.1;
+  if (_dampingHeelPitch>0.5) _dampingHeelPitch=0.5;
+
+  INFO( "HDG Damping factor taken for IIR-filter: %f", _dampingHdg );
+  INFO( "Heel/Pitch Damping factor taken for IIR-filter: %f", _dampingHeelPitch );
+
+  // set filter type
+  IMU_HdgFilter.setType(IIRFILTER_TYPE_DEG);
+  IMU_HdgFilter.setFC(_dampingHdg);
+  IMU_HeelFilter.setType(IIRFILTER_TYPE_LINEAR);
+  IMU_HeelFilter.setFC(_dampingHeelPitch);
+  IMU_PitchFilter.setType(IIRFILTER_TYPE_LINEAR);
+  IMU_PitchFilter.setFC(_dampingHeelPitch);
+
+
+  static const int col1 = 5;
+  static const int col2 = 200;
+  static const int row1 = 26;
+  static const int row2 = 50;
+  static const int row3 = 152;
+  static const int row4 = 182;
+
+  addLayer(new TextLayer(Point(col1, row1), Size(20, 20), "HDG ° Mag", ColorWhite, ColorBlack, FontDefault));
+  addLayer(new TextLayer(Point(col2, row1), Size(20, 20), "Calibration", ColorWhite, ColorBlack, FontDefault));
+  addLayer(new TextLayer(Point(col1, row3), Size(20, 20), "Heel °", ColorWhite, ColorBlack, FontDefault));
+  addLayer(new TextLayer(Point(col2, row3), Size(20, 20), "Pitch °", ColorWhite, ColorBlack, FontDefault));
+
+  hdgTL = new TextLayer(Point(col1, row2), Size(20, 20), "--", ColorWhite, ColorBlack, FontLarge);
+  calTL = new TextLayer(Point(col2, row2), Size(20, 20), "--", ColorWhite, ColorBlack, FontLarge);
+  heelTL  = new TextLayer(Point(col1, row4), Size(20, 20), "--", ColorWhite, ColorBlack, FontLarge);
+  pitchTL = new TextLayer(Point(col2, row4), Size(20, 20), "--", ColorWhite, ColorBlack, FontLarge);
+
+  addLayer(hdgTL);
+  addLayer(calTL);
+  addLayer(heelTL);
+  addLayer(pitchTL);
+
+  hub.subscribe(this);
+}
+void IMUMonitorPage::updateReceived(const SKUpdate& up) {
+
+  // No Updates coming when Calib below 3!!!
+  // Aproach is for trusted values only
+  // Disadvantage is, that the display is stuck to the last value!
+  // TODO: get Calibration from IMU Service and show on monitor (may be red = warning not trusted value)
+
+  if ( up.hasNavigationHeadingMagnetic() ) {
+    const SKValue& vm = up.getNavigationHeadingMagnetic();
+    _IMU_HDGFiltered = IMU_HdgFilter.filter( round ( SKRadToDeg( vm.getNumberValue()) * 10) / 10.0 );
+    //DEBUG("HDG: %f\n", round( SKRadToDeg( vm.getNumberValue()) * 10) / 10.0 );
+  }
+
+  if ( up.hasNavigationAttitude() ) {
+    const SKValue& vm = up.getNavigationAttitude();
+    _IMU_HeelFiltered = IMU_HeelFilter.filter( round( SKRadToDeg( vm.getAttitudeValue().roll ) * 10) / 10.0 );
+    _IMU_PitchFiltered = IMU_PitchFilter.filter( round( SKRadToDeg( vm.getAttitudeValue().pitch )* 10) / 10.0 );
+    //DEBUG("Heel: %f\n", round( SKRadToDeg( vm.getAttitudeValue().roll ) * 10) / 10.0);
+    //DEBUG("Pitch: %f\n", round( SKRadToDeg( vm.getAttitudeValue().pitch )* 10) / 10.0);
+  }
+
+
+  // Display interval 400ms
+  if (millis() > _nextPrint) {
+    _nextPrint = millis() + 400;
+
+
+    //DEBUG("%f\n", _IMU_HDGFiltered);
+    //DEBUG("%f\n",_IMU_PitchFiltered);
+    //DEBUG("%f\n",_IMU_HeelFiltered);
+    if ( _IMU_HDGFiltered < 361 && _IMU_HDGFiltered >= 0 )
+      hdgTL->setText(String( _IMU_HDGFiltered, 1) + "°        ");
+    if ( _IMU_PitchFiltered < 181 && _IMU_PitchFiltered > -181 )
+      pitchTL->setText(String( _IMU_PitchFiltered, 1 ) + "°     ");
+    if ( _IMU_HeelFiltered < 181 && _IMU_HeelFiltered > -181 )
+      heelTL->setText(String( _IMU_HeelFiltered, 1 ) + "°     ");
+
+  }
+}

--- a/src/host/pages/IMUMonitorPage.h
+++ b/src/host/pages/IMUMonitorPage.h
@@ -1,0 +1,57 @@
+/*
+  * Project:  KBox
+  * Purpose:  IMU Monitor Page for HDG, Cal, Heel & Pitch
+  * Author:   (c) Ronnie Zeiller, 2017
+  * KBox:     (c) 2016 Thomas Sarlandie thomas@sarlandie.net
+
+  The MIT License
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#include "common/ui/Page.h"
+#include "common/ui/TextLayer.h"
+#include "common/signalk/SKHub.h"
+#include "common/signalk/SKSubscriber.h"
+#include "util/iirfilter.h"
+
+class IMUMonitorPage : public Page, public SKSubscriber {
+private:
+  TextLayer *hdgTL, *heelTL, *pitchTL, *calTL;  // display cal planned for later
+  unsigned long int _nextPrint = 0;
+  uint16_t _IMUServiceInterval = 50;
+
+  iirfilter   IMU_HdgFilter;
+  iirfilter   IMU_HeelFilter;
+  iirfilter   IMU_PitchFilter;
+
+  double _dampingHdg;
+  double _dampingHeelPitch;
+
+  double _IMU_HDGFiltered;
+  double _IMU_PitchFiltered;
+  double _IMU_HeelFiltered;
+
+
+public:
+  IMUMonitorPage(SKHub &hub);
+
+
+  virtual void updateReceived(const SKUpdate &up);
+};

--- a/src/host/util/iirfilter.cpp
+++ b/src/host/util/iirfilter.cpp
@@ -1,0 +1,132 @@
+#include "iirfilter.h"
+#include <math.h>
+#include <KBoxLogging.h>
+
+
+iirfilter::iirfilter(double fc, filterType tp) {
+  if (tp == IIRFILTER_TYPE_DEG || tp == IIRFILTER_TYPE_LINEAR || tp == IIRFILTER_TYPE_RAD){
+    type = tp;
+  } else {
+    DEBUG("No IIRFILTER_TYP");
+    type = IIRFILTER_TYPE_LINEAR;
+  }
+  setFC(fc);
+  reset();
+  initialized = false;
+}
+
+double iirfilter::filter(double data) {
+    if (!wxIsNaN(data) && !wxIsNaN(b1)) {
+        if (wxIsNaN(accum)) {
+          accum = 0.0;
+          // DEBUG("Not Filtering");
+        }
+        else if ( !initialized ) {
+            accum = data;
+            initialized = true;
+        }
+        switch (type) {
+            case IIRFILTER_TYPE_LINEAR:
+                accum = accum * b1 + a0 * data;
+                break;
+
+            case IIRFILTER_TYPE_DEG:
+                unwrap(data);
+                accum = accum * b1 + a0 * (oldAng + 360.0*wraps);
+                break;
+
+            case IIRFILTER_TYPE_RAD:
+                unwrap(data);
+                accum = accum * b1 + a0 * (oldAng + 2.0*M_PI*wraps);
+                break;
+
+            default:
+                DEBUG("No IIRFILTER_TYP");
+        }
+    }
+    else {
+      // DEBUG("Not Filtering");
+      accum = data;
+    }
+    return get();
+}
+
+void iirfilter::reset(double a) {
+    accum = a;
+    oldAng = NAN;
+    wraps = 0;
+    initialized = true;
+}
+
+void iirfilter::setFC(double fc, bool resetAccum) {
+    if (wxIsNaN(fc) || fc <= 0.0)
+        a0 = b1 = NAN;  // NAN means no filtering will be done
+    else {
+        if ( resetAccum )
+            reset();
+        b1 = exp(-2.0 * 3.1415926535897932384626433832795 * fc);
+        a0 = 1.0 - b1;
+    }
+}
+
+void iirfilter::setType(filterType tp) {
+  if (tp == IIRFILTER_TYPE_DEG || tp == IIRFILTER_TYPE_LINEAR || tp == IIRFILTER_TYPE_RAD){
+    type = tp;
+  } else {
+    DEBUG("No IIRFILTER_TYP, Filter set to IIRFILTER_TYPE_LINEAR");
+    tp = IIRFILTER_TYPE_LINEAR;
+  }
+  reset();
+}
+
+double iirfilter::getFc(void) const
+{
+    if (wxIsNaN(b1))
+        return 0.0;
+    double fc = log(b1) / (-2.0 * M_PI);
+    return fc;
+}
+
+double iirfilter::get(void) const {
+    if (wxIsNaN(accum))
+        return accum;
+    double res = accum;
+    switch (type) {
+        case IIRFILTER_TYPE_DEG:
+            while (res < 0) res += 360.0;
+            while (res > 360) res -= 360.0;
+            break;
+
+        case IIRFILTER_TYPE_RAD:
+            while (res < 0) res += 2.0*M_PI;
+            while (res > 2.0*M_PI) res -= 2.0*M_PI;
+            break;
+        //case IIRFILTER_TYPE_LINEAR:
+        //    break;
+        default:
+          // nothing to do
+        break;
+    }
+    return res;
+}
+
+void iirfilter::unwrap(double ang) {
+    double pi;
+    switch ( type ) {
+    case IIRFILTER_TYPE_DEG:
+        pi = 180;
+        break;
+    case IIRFILTER_TYPE_RAD:
+        pi = M_PI;
+        break;
+    default:
+        return;
+    }
+    if ( ang - oldAng > pi ) {
+            wraps--;
+    }
+    else if ( ang - oldAng < -pi ) {
+        wraps++;
+    }
+    oldAng = ang;
+}

--- a/src/host/util/iirfilter.h
+++ b/src/host/util/iirfilter.h
@@ -1,0 +1,87 @@
+/******************************************************************************
+* iirfilter.h
+*
+* Project:  KBox
+* Purpose:  Class that implements single order inifinite-impulse-response filter
+* Author:   Transmitterdan, adaptions for KBox by Ronnie Zeiller 2017
+***************************************************************************
+*   Copyright (C) 2016                                                    *
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+*   This program is distributed in the hope that it will be useful,       *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+*   GNU General Public License for more details.                          *
+*                                                                         *
+*   You should have received a copy of the GNU General Public License     *
+*   along with this program; if not, write to the                         *
+*   Free Software Foundation, Inc.,                                       *
+*   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+***************************************************************************
+*/
+
+/**************************************************************************
+ * How to use:                                                            *
+ *                                                                        *
+ * To create a filter object declare on instance of iirfilter. There are  *
+ * 2 optional parameters to the constructor. The first (Fc) determines    *
+ * the filter cutoff frequency. A value of 0.5 is basically no filtering  *
+ * and smaller values decrease the cutoff frequency. If you think of the  *
+ * filter as being "fast" or "slow" then 0.5 is fastest and smaller values*
+ * are "slower". The second parameter (tp) selects whether the underlying *
+ * filtered values represent a linear value (such as speed) or a circular *
+ * angle such as direction. The angle can be either in radians or degrees.*
+ * These values can be changed on the "fly" with the setFC() and setType()*
+ * methods.                                                               *
+ * The main method is filter() which accepts a new unfiltered value and   *
+ * returns a fitered value. To obtain the most recent filter output use   *
+ * the get() method. Lesser used methods are getType (returns tp) and     *
+ * getFC() (returns FC). The reset() method resets the filter to zero.    *
+ **************************************************************************
+ */
+#if ! defined( IIRFILTER_CLASS_HEADER )
+#define IIRFILTER_CLASS_HEADER
+
+#define wxIsNaN(x) isnan(x)
+
+// Define filter types
+enum filterType
+{
+    IIRFILTER_TYPE_LINEAR = 1 << 0,
+    IIRFILTER_TYPE_DEG = 1 << 1,
+    IIRFILTER_TYPE_RAD = 1 << 2
+};
+
+class iirfilter
+{
+public:
+
+    iirfilter(double fc = 0.5, filterType tp = IIRFILTER_TYPE_LINEAR);
+    double filter(double data); // Return filtered data given new data point
+    void reset(double a = 0.0); // Clear filter
+    void setFC(double fc = 0.5, bool resetAccum=false);// Set cutoff frequency
+    void setType(filterType tp);       // Set type of filter (linear or angle type)
+    double getFc(void) const;         // Return cutoff frequency
+    filterType getType( void ) const { return type; };    // Return type of filter
+    double get(void) const;           // Return the current filtered data
+
+protected:
+
+    void unwrap(double ang);
+
+private:
+
+    double a0;
+    double b1;
+    double accum;
+    double oldAng;
+    int wraps;
+    filterType type;
+    bool initialized;
+};
+
+#endif


### PR DESCRIPTION
Filter is IIR-Filter as used in openCPN for damping of display in dashboard.

**What is missing and should/could be done:**
 - Setting for damping values by ini-file or similar 
 - for automatic damping (calculated by the IMUService interval) the real interval value should be taken (at the moment fixed value in main.cpp)
 - get cal-values from IMUService to show them too? 
- remove all the debug msg from the code after testing

**Note:** 
at the moment the display stucks to an old value, if there is no update due to bad calibration values!! (KBox minimum default SysCal 3 needed)
Workaround could be to check if there was no update since nnn ms and set the textlayers to something like "--"

**Remark:**
.....on the Display and in the code is mentioned "heel" and not "roll" as in KBox.
I would  suggest is to switch to "heel" as I think that "roll" is for large ship and "heel" is the more common expression for sailing boats. (formula for leeway, ORC calculations, openCPN Dashboard,....)