### PR TITLE
Change travis caching strategy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,12 @@ python:
 dist: trusty
 
 sudo: false
-cache:
-    directories:
-        - "~/.platformio"
+cache: pip
 
 install:
     - pip install -U platformio cpp-coveralls
 
 script:
-    - platformio update
     # This builds all the target
     - platformio run
     # Run the few unit tests (C code running on computer)


### PR DESCRIPTION
Caching the entire .platformio folder is not good because we will miss
update to core libraries and tools. Instead, we can reinstall them every
time.

@ronzeiller this is the proper way to fix the build issue.