### PR TITLE
Feature/file io kommands

### DIFF
--- a/src/common/comms/Kommand.h
+++ b/src/common/comms/Kommand.h
@@ -34,17 +34,61 @@ enum KommandIdentifier {
   KommandPong = 0x01,
   KommandErr = 0x0F,
   KommandLog = 0x10,
+
+  /**
+   * Kommand to read a file from the SDCard.
+   *
+   * Data:
+   *  - uint32_t: fileOpId - a identifier used in errors or replies
+   *  - uint32_t: startPosition - where to start reading from in file
+   *  - uint32_t: size - amount of bytes to read
+   *  - char[]: zero-terminated filename
+   *
+   * Replies with KommandFileReadReply or KommandFileError
+   */
   KommandFileRead = 0x20,
-  KommandFileReadReply = 0x21,
+
+  /**
+   * Kommand to write to a file on the SDCard.
+   *
+   * Data:
+   *  - uint32_t: fileOpId - a identifier used in errors or replies
+   *  - uint32_t: startPosition
+   *  - uint32_t: size
+   *  - char[]: zero-terminated filename
+   *  - uint8_t[]: data
+   */
+   KommandFileWrite = 0x21,
+
+  /**
+   * Response to a KommandFileRead
+   *
+   * Data:
+   *  - uint32_t: fileOpId - a identifier used in errors or replies
+   *  - uint32_t: size
+   *  - uint8_t[]: data
+   */
+  KommandFileReadReply = 0x22,
+
+  /**
+   * Data:
+   *  - uint32_t: fileOpId - a identifier used in errors or replies
+   *  - uint32_t: error code (KommandFileErrors)
+   */
   KommandFileError = 0x2F,
+
   KommandScreenshot = 0x30,
   KommandScreenshotData = 0x31,
+
   KommandNMEASentence = 0x40,
   KommandSKData = 0x42
 };
 
 enum class KommandFileErrors {
-    NoSuchFile
+    AOK,
+    NoSuchFile,
+    InvalidWriteError,
+    WriteError
 };
 
 class Kommand {

--- a/src/common/comms/Kommand.h
+++ b/src/common/comms/Kommand.h
@@ -34,10 +34,17 @@ enum KommandIdentifier {
   KommandPong = 0x01,
   KommandErr = 0x0F,
   KommandLog = 0x10,
+  KommandFileRead = 0x20,
+  KommandFileReadReply = 0x21,
+  KommandFileError = 0x2F,
   KommandScreenshot = 0x30,
   KommandScreenshotData = 0x31,
   KommandNMEASentence = 0x40,
   KommandSKData = 0x42
+};
+
+enum class KommandFileErrors {
+    NoSuchFile
 };
 
 class Kommand {

--- a/src/common/comms/KommandReader.cpp
+++ b/src/common/comms/KommandReader.cpp
@@ -29,7 +29,12 @@ KommandReader::KommandReader(const uint8_t *buffer, size_t size) : buffer(buffer
 }
 
 uint16_t KommandReader::getKommandIdentifier() const {
-  return buffer[0] + (buffer[1] << 8);
+  if (size >= 2) {
+    return buffer[0] + (buffer[1] << 8);
+  }
+  else {
+    return 0;
+  }
 }
 
 uint8_t KommandReader::read8() {
@@ -44,7 +49,7 @@ uint16_t KommandReader::read16() {
     return 0;
   }
   uint16_t w = buffer[index] + (buffer[index + 1] << 8);
-  buffer += 2;
+  index += 2;
   return w;
 }
 
@@ -60,6 +65,10 @@ uint32_t KommandReader::read32() {
 const char *KommandReader::readNullTerminatedString() {
   char *s = (char*)buffer + index;
 
+  if (index >= size) {
+    return 0;
+  }
+
   // Make sure there is a 0 termination before end of buffer
   // At the same time, advance index to next element in buffer.
   while (index < size && buffer[index] != 0) {
@@ -67,7 +76,7 @@ const char *KommandReader::readNullTerminatedString() {
   }
 
   // Check that the string is properly null-terminated
-  if (buffer[index] != 0) {
+  if (index == size || buffer[index] != 0) {
     return 0;
   }
 
@@ -88,4 +97,12 @@ size_t KommandReader::dataSize() const {
   else {
     return 0;
   }
+}
+
+const uint8_t* KommandReader::dataBuffer() const {
+  return buffer + 2;
+}
+
+size_t KommandReader::dataIndex() const {
+  return index - 2;
 }

--- a/src/common/comms/KommandReader.h
+++ b/src/common/comms/KommandReader.h
@@ -79,6 +79,16 @@ class KommandReader {
     const char *readNullTerminatedString();
 
     /**
+     * Gets a pointer to the data.
+     */
+    const uint8_t* dataBuffer() const;
+
+    /**
+     * Get the current value of the reading index.
+     */
+    size_t dataIndex() const;
+
+    /**
      * Start reading from the beginning of the packet again.
      * (The first byte after the KommandIdentifier header.
      */

--- a/src/host/comms/KommandHandlerFile.cpp
+++ b/src/host/comms/KommandHandlerFile.cpp
@@ -28,17 +28,14 @@
   THE SOFTWARE.
 */
 
-#pragma once
+#include "KommandHandlerFile.h"
 
-#include "comms/KommandHandlerFile.h"
+void KommandHandlerFile::sendFileError(SlipStream &replyStream,
+                                       uint32_t fileOpId,
+                                       const KommandFileErrors &error) {
+  FixedSizeKommand<8> errorFrame(KommandFileError);
+  errorFrame.append32(fileOpId);
+  errorFrame.append32(static_cast<uint32_t>(error));
 
-/**
- * Handle KommandFileRead operations.
- */
-class KommandHandlerFileRead : public KommandHandlerFile {
-  private:
-    static const int MaxReadSize = 2048;
-
-  public:
-    bool handleKommand(KommandReader &kreader, SlipStream &replyStream) override;
-};
+  replyStream.writeFrame(errorFrame.getBytes(), errorFrame.getSize());
+}

--- a/src/host/comms/KommandHandlerFile.h
+++ b/src/host/comms/KommandHandlerFile.h
@@ -30,15 +30,10 @@
 
 #pragma once
 
-#include "comms/KommandHandlerFile.h"
+#include <common/comms/KommandHandler.h>
 
-/**
- * Handle KommandFileRead operations.
- */
-class KommandHandlerFileRead : public KommandHandlerFile {
-  private:
-    static const int MaxReadSize = 2048;
-
-  public:
-    bool handleKommand(KommandReader &kreader, SlipStream &replyStream) override;
+class KommandHandlerFile : public KommandHandler {
+  protected:
+    void sendFileError(SlipStream &replyStream,
+                       uint32_t fileOpId, const KommandFileErrors &error);
 };

--- a/src/host/comms/KommandHandlerFileRead.cpp
+++ b/src/host/comms/KommandHandlerFileRead.cpp
@@ -1,0 +1,77 @@
+/*
+     __  __     ______     ______     __  __
+    /\ \/ /    /\  == \   /\  __ \   /\_\_\_\
+    \ \  _"-.  \ \  __<   \ \ \/\ \  \/_/\_\/_
+     \ \_\ \_\  \ \_____\  \ \_____\   /\_\/\_\
+       \/_/\/_/   \/_____/   \/_____/   \/_/\/_/
+
+  The MIT License
+
+  Copyright (c) 2017 Thomas Sarlandie thomas@sarlandie.net
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#include <KBoxLogging.h>
+#include <KBoxHardware.h>
+#include "KommandHandlerFileRead.h"
+
+bool KommandHandlerFileRead::handleKommand(KommandReader &kreader, SlipStream &replyStream) {
+  if (kreader.getKommandIdentifier() != KommandFileRead) {
+    return false;
+  }
+
+  uint32_t readId = kreader.read32();
+  uint32_t startPosition = kreader.read32();
+  uint32_t size = kreader.read32();
+  const char *fname = kreader.readNullTerminatedString();
+
+  if (KBox.getSdFat().exists(fname)) {
+    File f = KBox.getSdFat().open(fname, O_READ);
+
+    if (size > f.fileSize()) {
+      size = f.fileSize();
+    }
+    if (size > MaxReadSize) {
+      size = MaxReadSize;
+    }
+
+    FixedSizeKommand<MaxReadSize + 3*4> replyFrame(KommandFileReadReply);
+    replyFrame.append32(readId);
+    replyFrame.append32(startPosition);
+    replyFrame.append32(size);
+
+    uint8_t *bytes;
+    size_t *index;
+    replyFrame.captureBuffer(&bytes, &index);
+
+    int readCount = f.read(bytes + *index, size);
+    *index += readCount;
+
+    replyStream.writeFrame(replyFrame.getBytes(), replyFrame.getSize());
+  }
+  else {
+    FixedSizeKommand<64> errorFrame(KommandFileError);
+    errorFrame.append32(readId);
+    errorFrame.append32(static_cast<uint32_t>(KommandFileErrors::NoSuchFile));
+
+    replyStream.writeFrame(errorFrame.getBytes(), errorFrame.getSize());
+  }
+  return true;
+}

--- a/src/host/comms/KommandHandlerFileRead.h
+++ b/src/host/comms/KommandHandlerFileRead.h
@@ -1,4 +1,10 @@
 /*
+     __  __     ______     ______     __  __
+    /\ \/ /    /\  == \   /\  __ \   /\_\_\_\
+    \ \  _"-.  \ \  __<   \ \ \/\ \  \/_/\_\/_
+     \ \_\ \_\  \ \_____\  \ \_____\   /\_\/\_\
+       \/_/\/_/   \/_____/   \/_____/   \/_/\/_/
+
   The MIT License
 
   Copyright (c) 2017 Thomas Sarlandie thomas@sarlandie.net
@@ -24,42 +30,12 @@
 
 #pragma once
 
-#include <KBoxLogging.h>
-#include <KBoxLoggerStream.h>
-#include <comms/KommandHandlerFileRead.h>
-#include "comms/SlipStream.h"
-#include "os/Task.h"
-#include "ui/GC.h"
-#include "comms/KommandHandlerPing.h"
-#include "comms/KommandHandlerScreenshot.h"
+#include "comms/KommandHandler.h"
 
-class USBService : public Task, public KBoxLogger {
+class KommandHandlerFileRead : public KommandHandler {
   private:
-    static const size_t MaxLogFrameSize = 256;
-
-    SlipStream _slip;
-    KBoxLoggerStream _streamLogger;
-    KommandHandlerPing _pingHandler;
-    KommandHandlerScreenshot _screenshotHandler;
-    KommandHandlerFileRead _fileReadHandler;
-
-    enum USBConnectionState{
-      ConnectedDebug,
-      ConnectedFrame,
-      ConnectedESPProgramming
-    };
-    USBConnectionState _state;
-
-    void loopConnectedFrame();
-    void loopConnectedESPProgramming();
-
-    void sendLogFrame(KBoxLoggingLevel level, const char *fname, int lineno, const char *fmt, va_list fmtargs);
+    static const int MaxReadSize = 2048;
 
   public:
-    USBService(GC &gc);
-    ~USBService() {};
-
-    void setup();
-    void loop();
-    virtual void log(enum KBoxLoggingLevel level, const char *fname, int lineno, const char *fmt, va_list args);
+    bool handleKommand(KommandReader &kreader, SlipStream &replyStream) override;
 };

--- a/src/host/comms/KommandHandlerFileWrite.h
+++ b/src/host/comms/KommandHandlerFileWrite.h
@@ -32,12 +32,9 @@
 
 #include "comms/KommandHandlerFile.h"
 
-/**
- * Handle KommandFileRead operations.
- */
-class KommandHandlerFileRead : public KommandHandlerFile {
+class KommandHandlerFileWrite : public KommandHandlerFile {
   private:
-    static const int MaxReadSize = 2048;
+    static const int MaxWriteSize = 2048;
 
   public:
     bool handleKommand(KommandReader &kreader, SlipStream &replyStream) override;

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -80,6 +80,7 @@ void setup() {
     JsonObject &root =jsonBuffer.parseObject(configFile);
 
     if (root.success()) {
+      DEBUG("Loading configuration from SDCard");
       configParser.parseKBoxConfig(root, config);
     }
     else {
@@ -87,8 +88,10 @@ void setup() {
     }
   }
   else {
+    DEBUG("No configuration file found. Using defaults.");
     configParser.defaultConfig(config);
   }
+
 
   // Instantiate all our services
   WiFiService *wifi = new WiFiService(config.wifiConfig, skHub, gc);

--- a/src/host/services/USBService.cpp
+++ b/src/host/services/USBService.cpp
@@ -105,7 +105,8 @@ void USBService::loopConnectedFrame() {
 
     KommandReader kr = KommandReader(frame, len);
 
-    KommandHandler *handlers[] = { &_pingHandler, &_screenshotHandler, 0 };
+    KommandHandler *handlers[] = { &_pingHandler, &_screenshotHandler,
+                                   &_fileReadHandler, nullptr };
     if (KommandHandler::handleKommandWithHandlers(handlers, kr, _slip)) {
       KBoxMetrics.event(KBoxEventUSBValidKommand);
     }

--- a/src/host/services/USBService.cpp
+++ b/src/host/services/USBService.cpp
@@ -106,7 +106,8 @@ void USBService::loopConnectedFrame() {
     KommandReader kr = KommandReader(frame, len);
 
     KommandHandler *handlers[] = { &_pingHandler, &_screenshotHandler,
-                                   &_fileReadHandler, nullptr };
+                                   &_fileReadHandler, &_fileWriteHandler,
+                                   nullptr };
     if (KommandHandler::handleKommandWithHandlers(handlers, kr, _slip)) {
       KBoxMetrics.event(KBoxEventUSBValidKommand);
     }

--- a/src/host/services/USBService.h
+++ b/src/host/services/USBService.h
@@ -32,6 +32,8 @@
 #include "ui/GC.h"
 #include "comms/KommandHandlerPing.h"
 #include "comms/KommandHandlerScreenshot.h"
+#include "comms/KommandHandlerFileRead.h"
+#include "comms/KommandHandlerFileWrite.h"
 
 class USBService : public Task, public KBoxLogger {
   private:
@@ -42,6 +44,7 @@ class USBService : public Task, public KBoxLogger {
     KommandHandlerPing _pingHandler;
     KommandHandlerScreenshot _screenshotHandler;
     KommandHandlerFileRead _fileReadHandler;
+    KommandHandlerFileWrite _fileWriteHandler;
 
     enum USBConnectionState{
       ConnectedDebug,
@@ -53,7 +56,8 @@ class USBService : public Task, public KBoxLogger {
     void loopConnectedFrame();
     void loopConnectedESPProgramming();
 
-    void sendLogFrame(KBoxLoggingLevel level, const char *fname, int lineno, const char *fmt, va_list fmtargs);
+    void sendLogFrame(KBoxLoggingLevel level, const char *fname, int lineno,
+                      const char *fmt, va_list fmtargs);
 
   public:
     USBService(GC &gc);
@@ -61,5 +65,6 @@ class USBService : public Task, public KBoxLogger {
 
     void setup();
     void loop();
-    virtual void log(enum KBoxLoggingLevel level, const char *fname, int lineno, const char *fmt, va_list args);
+    void log(enum KBoxLoggingLevel level, const char *fname, int lineno,
+             const char *fmt, va_list args) override;
 };

--- a/src/test/comms/KommandReaderTest.cpp
+++ b/src/test/comms/KommandReaderTest.cpp
@@ -1,0 +1,91 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017 Thomas Sarlandie thomas@sarlandie.net
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+/*
+ * This test executes full conversion of NMEA sentences into SignalK and then
+ * back into NMEA2000 messages and validates that the output matches what is
+ * expected.
+ */
+
+#include <KBoxLogging.h>
+#include "../KBoxTest.h"
+#include "common/comms/KommandReader.h"
+
+TEST_CASE("KommandReader") {
+  SECTION("Empty kommand") {
+    const uint8_t frame[] = {};
+
+    KommandReader kr = KommandReader(frame, sizeof(frame));
+
+    CHECK(kr.getKommandIdentifier() == 0);
+    CHECK(kr.dataSize() == 0);
+    CHECK(kr.dataIndex() == 0);
+
+    CHECK(kr.read8() == 0);
+    CHECK(kr.read16() == 0);
+    CHECK(kr.read32() == 0);
+    CHECK(kr.readNullTerminatedString() == nullptr);
+
+    CHECK(kr.dataIndex() == 0);
+  }
+
+  SECTION("Kommand with some data") {
+    const uint8_t frame[] = {0x2a, 0x00,
+                             0x01,
+                             0x01, 0x02,
+                             0x01, 0x02, 0x03, 0x04,
+                             'a', 'b', 'c', '\0'
+    };
+
+    KommandReader kr = KommandReader(frame, sizeof(frame));
+
+    CHECK(kr.getKommandIdentifier() == 42);
+    CHECK(kr.dataSize() == 11);
+    CHECK(kr.dataIndex() == 0);
+
+    CHECK(kr.read8() == 1);
+    CHECK(kr.dataIndex() == 1);
+
+    CHECK(kr.read16() == 0x0201);
+    CHECK(kr.dataIndex() == 3);
+
+    CHECK(kr.read32() == 0x04030201);
+    CHECK(kr.dataIndex() == 7);
+
+    auto originalString = reinterpret_cast<const char *>(&frame[9]);
+    auto readString = kr.readNullTerminatedString();
+    CHECK( readString == originalString );
+
+    CHECK(kr.dataIndex() == 11);
+  }
+
+  SECTION("Kommand with invalid string") {
+    const uint8_t frame[] = {0x2a, 0x00,
+                             'a', 'b', 'c', 'd'
+    };
+
+    KommandReader kr = KommandReader(frame, sizeof(frame));
+    CHECK( kr.readNullTerminatedString() == 0 );
+  }
+}

--- a/tools/kbox.py
+++ b/tools/kbox.py
@@ -8,8 +8,16 @@ import struct
 import time
 import png
 import random
+import logging
+import sys
 
-""" Courtesy of esptool.py - GPL """
+""" Courtesy of esptool.py - GPL 
+
+Modified to return a tuple (packer, Exception). Caller is responsible to decide
+what to do with the Exception if it exits.
+Kudos: https://stackoverflow.com/questions/11366892/handle-generator-exceptions-in-its-consumer
+
+"""
 def slip_reader(port):
     """Generator to read SLIP packets from a serial port.
     Yields one full SLIP packet at a time, raises exception on timeout or invalid data.
@@ -24,7 +32,12 @@ def slip_reader(port):
         waiting = port.inWaiting()
         read_bytes = port.read(1 if waiting == 0 else waiting)
         if read_bytes == '':
-            raise FatalError("Timed out waiting for packet %s" % ("header" if partial_packet is None else "content"))
+            if partial_packet is None:
+                logging.info("Timed out waiting for packet header")
+                yield None
+            else:
+                logging.info("Timed out waiting for packet content")
+                yield None
 
         for b in read_bytes:
             if partial_packet is None:  # waiting for packet header
@@ -33,7 +46,7 @@ def slip_reader(port):
                     connected = True
                 else:
                     if connected:
-                        raise FatalError('Invalid head of packet (%r)' % b)
+                        raise KBoxError('Invalid head of packet (%r)' % b)
                     else:
                         # Ignore errors until we are connected (aka seen one valid packet)
                         pass
@@ -45,7 +58,7 @@ def slip_reader(port):
                 elif b == '\xdd':
                     partial_packet += '\xdb'
                 else:
-                    raise FatalError('Invalid SLIP escape (%r%r)' % ('\xdb', b))
+                    raise KBoxError('Invalid SLIP escape (%r%r)' % ('\xdb', b))
             elif b == '\xdb':  # start of escape sequence
                 in_escape = True
             elif b == '\xc0':  # end of packet
@@ -54,7 +67,7 @@ def slip_reader(port):
             else:  # normal byte in packet
                 partial_packet += b
 
-class FatalError(RuntimeError):
+class KBoxError(RuntimeError):
     """
     Wrapper class for runtime errors that aren't caused by internal bugs, but by
     invalid KBox responses or input content.
@@ -68,7 +81,8 @@ class FatalError(RuntimeError):
         Return a fatal error object that includes the hex values of
         'result' as a string formatted argument.
         """
-        return FatalError(message % ", ".join(hex(ord(x)) for x in result))
+        return KBoxError(message + " [" +  ", ".join(hex(ord(x)) for x in
+                                                    result) + "]")
 
 class KBox(object):
     KommandPing = 0x00
@@ -76,7 +90,8 @@ class KBox(object):
     KommandErr = 0x0F
     KommandLog = 0x10
     KommandFileRead = 0x20
-    KommandFileReadReply = 0x21
+    KommandFileWrite = 0x21
+    KommandFileReadReply = 0x22
     KommandFileError = 0x2F
     KommandScreenshot = 0x30
     KommandScreenshotData = 0x31
@@ -91,7 +106,12 @@ class KBox(object):
         self._debug = debug
 
     def read(self):
-        return self._slip_reader.next()
+        try:
+            return self._slip_reader.next()
+        except KBoxError as e:
+            # reset reader on errors
+            self._slip_reader = slip_reader(self._port)
+            raise e
 
     def write(self, packet):
         """
@@ -103,40 +123,53 @@ class KBox(object):
               + '\xc0'
         self._port.write(buf)
 
-    def readCommand(self, command):
+    def readCommand(self, command, timeout = 1):
         """
         Reads incoming frame until a frame with specified command is received.
         """
 
+        timer = time.time()
+
         while True:
-            frame = self.read()
+            if time.time() > timer + timeout:
+                raise KBoxError("timed out")
+
+            try:
+                frame = self.read()
+            except KBoxError as e:
+                logging.warn(e.message)
+                continue
+
+            if frame is None:
+                continue
 
             if self._debug:
                 print "> ({}) {}".format(len(frame), " ".join("{:02x}".format(ord(c)) for c in frame))
 
-            if len(frame) < 2:
-                raise FatalError.WithFrame("Frame is too short to be valid (%s)", frame)
+            if not frame or len(frame) < 2:
+                raise KBoxError.WithFrame("Frame is too short to be valid", frame)
 
             (cmd,) = struct.unpack('<H', frame[0:2])
 
             if cmd == command:
                 return frame[2:]
             elif cmd == KBox.KommandErr:
-                raise FatalError("KBox responded with an error")
+                raise KBoxError.WithFrame("KBox responded with an error", frame)
             elif cmd == KBox.KommandFileError:
                 data = frame[2:]
                 if len(data) != 8:
-                    raise FatalError("Invalid KommandFileError size {"
-                                     "}".format(len(data)))
+                    raise KBoxError.WithFrame("Invalid KommandFileError size {}"
+                                              .format(len(data), frame))
 
                 (fileid, errno) = struct.unpack('<LL', data)
-                raise FatalError("KBox responded with a file error {} for "
-                                 "file {}".format(errno, fileid))
+                raise KBoxError.WithFrame("KBox responded with a file error {} "
+                                           "for file {}".format(errno, fileid),
+                                          frame)
             elif cmd == KBox.KommandLog:
                 # Keep printing log messages while waiting
                 self.printLog(frame[2:])
             else:
-                print("Got unexpected command with id {}".format(cmd))
+                print("Got unexpected frame with id {}".format(cmd))
 
     def parseLogCommand(self, data):
         logLevels = { 0: "hD", 1: "hI", 2: "hE", 3: "wD", 4: "wI", 5: "wE" }
@@ -165,14 +198,14 @@ class KBox(object):
         while not ponged:
             resp = self.readCommand(KBox.KommandPong)
             if len(resp) != 4:
-                raise FatalError("KBox ponged with wrong size frame ({} instead of 4)".format(len(resp)))
+                raise KBoxError("KBox ponged with wrong size frame ({} instead of 4)".format(len(resp)))
             else:
                 (data,) = struct.unpack('<I', resp)
                 print("PONG[{}] in {} ms".format(data, (time.time() - t0) * 1000))
                 ponged = True
 
     def command(self, command, data = ""):
-        print("Sending cmd {} len {}".format(command, len(data)))
+        logging.debug("Sending cmd {} len {}".format(command, len(data)))
         t0 = time.time()
         pkt = struct.pack('<H', command) + data
         self.write(pkt)
@@ -188,7 +221,8 @@ class KBox(object):
         data = self.readCommand(KBox.KommandScreenshotData)
         (y,) = struct.unpack('<H', data[0:2])
         pixelData = data[2:]
-        pixels = [ KBox.convertToRgb(struct.unpack('<H', pixelData[i:i+2])[0]) for i in range(0, len(pixelData), 2) ]
+        pixels = [ KBox.convertToRgb(struct.unpack('<H', pixelData[i:i+2])[0])
+                   for i in range(0, len(pixelData), 2) ]
         pixelsByLine = [ pixels[i:i+320] for i in range(0, len(pixels), 320) ]
 
         return (y, pixelsByLine)
@@ -202,10 +236,31 @@ class KBox(object):
             capturedLines = capturedLines + len(rect)
             pixels.extend(rect)
 
-        print "Captured screenshot with {} lines in {:.0f} ms".format(len(pixels), (time.time() - t0)*1000)
-        png.from_array(pixels, 'RGB').save('screenshot.png')
+        print "Captured screenshot with {} lines in {:.0f} ms"\
+                .format(len(pixels), (time.time() - t0)*1000)
+        return png.from_array(pixels, 'RGB')
 
-    def read_file(self, filename, start_position = 0, size = 32 * 1024 * 1024):
+    def read_file(self, filename):
+        t0 = time.time()
+
+        data = ""
+        block_count = 0
+        while True:
+            block = self.read_file_block(filename, len(data))
+            block_count = block_count + 1
+            data = data + block
+            if len(block) == 0:
+                break
+
+        duration = time.time() - t0
+        speed = len(data) / duration
+        logging.info("Read file {} ({} bytes) in {}ms. {} kB/s. ({} blocks)"
+                     .format(filename, len(data), duration * 1000, speed/1024,
+                             block_count))
+        return data
+
+    def read_file_block(self, filename, start_position = 0, size = 32 * 1024 *
+                                                               1024):
         read_id = int(random.random() * 2**32)
 
         request = struct.pack('<LLL', read_id, start_position, size)
@@ -213,29 +268,76 @@ class KBox(object):
 
         self.command(KBox.KommandFileRead, request)
 
-        done = False
-        file_data = []
-        while not done:
-            data = self.readCommand(KBox.KommandFileReadReply)
+        data = self.readCommand(KBox.KommandFileReadReply)
 
-            (replyReadId, replyStartPos, replySize) = struct.unpack('<LLL',
-                                                                    data[0:12])
+        (reply_read_id, reply_size) = struct.unpack('<LL', data[0:8])
 
-            if replyReadId != read_id:
-                print("Got a read reply for another read ({})".format(
-                    replyReadId))
+        if reply_read_id != read_id:
+            raise KBoxError.WithFrame("Got a read reply for another read ({"
+                                       "} <> {})".format(hex(reply_read_id),
+                                                         hex(read_id)),
+                                      data)
+
+        if len(data) != reply_size + 8:
+            raise KBoxError.WithFrame("Invalid reply length - Got {} bytes. "
+                                        "Should be {}+8={}"
+                                      .format(len(data), reply_size,
+                                                reply_size+8),
+                                      data)
+
+        logging.debug("Read {} bytes from pos {}".format(reply_size,
+                                                     start_position))
+        return data[8:8+reply_size]
+
+    def write_file(self, filename, data, block_size = 2000):
+        t0 = time.time()
+        bytes_sent = 0
+        block_count = 0
+        while bytes_sent < len(data):
+            remaining_bytes = len(data) - bytes_sent
+            if remaining_bytes > block_size:
+                remaining_bytes = block_size
+
+            block = data[bytes_sent:bytes_sent + remaining_bytes]
+            self.write_file_block(filename, block, bytes_sent)
+            bytes_sent = bytes_sent + remaining_bytes
+            block_count = block_count + 1
+
+        duration = time.time() - t0
+        speed = len(data) / duration
+
+        logging.info("Wrote file {} ({} bytes) in {}ms. {} kB/s. ({} blocks)"
+                     .format(filename, len(data), duration * 1000, speed / 1024,
+                             block_count))
+
+    def write_file_block(self, filename, data, start_position = 0, retries = 3):
+        write_id = int(random.random() * 2**32)
+
+        request = struct.pack('<LLL', write_id, start_position, len(data))
+        request = request + filename + '\0'
+        request = request + data
+
+        while retries > 0:
+            self.command(KBox.KommandFileWrite, request)
+
+            try:
+                data = self.readCommand(KBox.KommandFileError, timeout = 0.1)
+            except KBoxError as e:
+                logging.warn(e.message)
+                retries = retries - 1
                 continue
 
-            if len(data) != replySize + 12:
-                print("Invalid reply length - Got {} bytes. Should be {}+12={"
-                      "}".format(len(data), replySize, replySize+12))
-            else:
-                print("Read {} bytes from pos {}".format(replySize, replyStartPos))
-                file_data[start_position:start_position + replySize] = data[12:12+replySize]
+            (reply_write_id, reply_error) = struct.unpack('<LL', data[0:8])
+            if reply_write_id != write_id:
+                raise KBoxError.WithFrame("Got a file error for another operation"
+                                          "({})".format(reply_read_id), data)
+            if reply_error != 0:
+                raise KBoxError.WithFrame("Write Error ({})".format(reply_error),
+                                          data)
+            # success!
+            return
 
-            done = True
-
-        return file_data
+        raise KBoxError("Failed to write block - retries exceeded")
 
     @staticmethod
     def convertToRgb(pixel):
@@ -253,11 +355,24 @@ def main():
     subparsers = parser.add_subparsers(dest = "command")
     subparsers.add_parser("ping")
     subparsers.add_parser("logs")
-    subparsers.add_parser("screenshot")
-    fileread_parser = subparsers.add_parser("fileread")
-    fileread_parser.add_argument("filename")
+
+    screenshot_parser = subparsers.add_parser("screenshot")
+    screenshot_parser.add_argument("filename", default = 'screenshot.png')
+
+    file_read_parser = subparsers.add_parser("fread")
+    file_read_parser.add_argument("filename")
+    file_read_parser.add_argument("destination", type = argparse.FileType('w'),
+                                  default = sys.stdout)
+
+    file_write_parser = subparsers.add_parser("fwrite")
+    file_write_parser.add_argument("filename")
 
     args = parser.parse_args()
+
+    if args.debug:
+        logging.basicConfig(level = logging.DEBUG)
+    else:
+        logging.basicConfig(level = logging.INFO)
 
     kbox = KBox(args.port, args.debug)
 
@@ -267,7 +382,7 @@ def main():
         try:
             p = kbox.read()
             ready = True
-        except FatalError as e:
+        except KBoxError as e:
             print e
 
     if args.command == "ping":
@@ -283,10 +398,17 @@ def main():
             log = kbox.readCommand(KBox.KommandLog)
             kbox.printLog(log)
     elif args.command == "screenshot":
-        kbox.takeScreenshot()
-    elif args.command == "fileread":
+        png = kbox.takeScreenshot()
+        png.from_array(pixels, 'RGB').save(args.filename)
+
+    elif args.command == "fread":
         data = kbox.read_file(args.filename)
-        print(data)
+        args.destination.write(data)
+
+    elif args.command == "fwrite":
+        with open(args.filename, 'r') as f:
+            data = f.read()
+            kbox.write_file(args.filename, data)
 
 if __name__ == '__main__':
     main()

--- a/tools/kboxtester.py
+++ b/tools/kboxtester.py
@@ -4,7 +4,7 @@ import time
 import re
 import serial
 from termcolor import colored
-from kbox import KBox,FatalError
+from kbox import KBox,KBoxError
 
 """
 Helper methods to interact with KBox.
@@ -103,7 +103,7 @@ def main():
             p = kbox.ping(42)
             ready = True
             print "Connected!"
-        except FatalError as e:
+        except KBoxError as e:
             print e
 
     tests = []


### PR DESCRIPTION
@ronzeiller I wanted an easy way to test different config files so I wrote a few `Kommand` that can be used to read/write files to the SDCard.

Right now I am using that with a python script on my computer but we will be able to re-use the same code to read/write files from the WiFi module.

I thought you probably did not get a chance to see this part of the code so I put it in a separate pull-request. I am going to merge it but let me know if you have any comments or questions!

Example of use:

```
$ tools/kbox.py --port /dev/tty.usbmodem1411 fread test3.jpg test4.jpg
> wD main.cpp:92 Still running ... 0 connected clients - 34808 heap - IP: 0.0.0.0
> wD main.cpp:92 Still running ... 0 connected clients - 34808 heap - IP: 0.0.0.0
> wD main.cpp:92 Still running ... 0 connected clients - 34808 heap - IP: 0.0.0.0
(...)
> wD main.cpp:92 Still running ... 0 connected clients - 34808 heap - IP: 0.0.0.0
> wD main.cpp:92 Still running ... 0 connected clients - 34808 heap - IP: 0.0.0.0
INFO:root:Read file test3.jpg (2409758 bytes) in 18510.2419853ms. 127.133902341 kB/s. (1178 blocks)
```