### PR TITLE
Bugfix/wifi crashes -> Go back to older esp framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,15 +192,19 @@ been possible!**
 
 ## Changelog
 
+ * 2018 02 16 - v1.2.2
+   * Go back to older version of ESP8266 framework (2.3 via framework 1.5) to
+     get rid of random crashes. Still need to investigate more but we do not
+     need 2.4 at the moment.
  * 2018 02 15 - v1.2.1
    * Send PGN 130314 for high-resolution barometer data on NMEA2000 networks
      (that is in addition to PGN 130310 which was already sent before).
  * 2018 02 10 - v1.2.0
-   * Configuration option for WiFi. KBox can act as an access point and can 
+   * Configuration option for WiFi. KBox can act as an access point and can
    also connect to an existing network. Both are possible at the same time.
    * KBox now shows WiFi info on the screen (status as a client and as an
    access point), number of clients connected, IP address)
-   * KBox now announces its SignalK "self" properly and you can set your own 
+   * KBox now announces its SignalK "self" properly and you can set your own
    MMSI via the config file.
    * Updated ESP8266 framework version to 2.4.
    * Fixed a bug where SDCard would not show free space properly

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,10 +60,10 @@ lib_deps =
 [env:esp]
 src_filter = +<common/*>,+<esp/*>
 # no-strict-aliasing required here due to ESP+NMEA2000 incompatibilities
-build_flags = -Wall -Werror -Wno-strict-aliasing
+build_flags = -Wall -Wno-strict-aliasing
     -Isrc/common -Isrc/esp
     -DHAVE_STRLCPY -DHAVE_STRLCAT
-platform=espressif8266
+platform = file:///Users/thomas/work/platform-espressif8266
 framework = arduino
 board = esp_wroom_02
 extra_scripts =

--- a/platformio.ini
+++ b/platformio.ini
@@ -63,7 +63,7 @@ src_filter = +<common/*>,+<esp/*>
 build_flags = -Wall -Wno-strict-aliasing
     -Isrc/common -Isrc/esp
     -DHAVE_STRLCPY -DHAVE_STRLCAT
-platform = file:///Users/thomas/work/platform-espressif8266
+platform = https://github.com/sarfata/platform-espressif8266#release/v1.5.0
 framework = arduino
 board = esp_wroom_02
 extra_scripts =

--- a/src/esp/main.cpp
+++ b/src/esp/main.cpp
@@ -70,7 +70,7 @@ static void reportStatus(ESPState state, uint16_t dhcpClients = 0,
 static void configurationCallback(const WiFiConfiguration&);
 
 static void onGotIP(const WiFiEventStationModeGotIP&);
-static void onDHCPTimeout(void);
+//static void onDHCPTimeout(void);
 static void onStationModeConnected(const WiFiEventStationModeConnected&);
 static void onStationModeDisconnected(const WiFiEventStationModeDisconnected&);
 
@@ -95,7 +95,7 @@ void setup() {
   wiFiConfigurationHandler.setCallback(configurationCallback);
 
   onGotIPHandler = WiFi.onStationModeGotIP(onGotIP);
-  onDhcpTimeoutHandler = WiFi.onStationModeDHCPTimeout(onDHCPTimeout);
+//  onDhcpTimeoutHandler = WiFi.onStationModeDHCPTimeout(onDHCPTimeout);
   onStationModeConnectedHandler =
     WiFi.onStationModeConnected(onStationModeConnected);
   onStationModeDisconnectedHandler =
@@ -146,8 +146,8 @@ void loop() {
     case ESPState::ESPConfigured:
       // We are connected. Report status every 500ms.
       if (lastMessageTimer > 500) {
-        DEBUG("Still running ... %i connected clients - %i heap",
-              server.clientsCount() + webServer.countClients(), ESP.getFreeHeap());
+        DEBUG("Still running ... %i connected clients - %i heap - uptime: %is",
+              server.clientsCount() + webServer.countClients(), ESP.getFreeHeap(), millis() / 1000);
         reportStatus(espState,
                      WiFi.softAPgetStationNum(),
                      server.clientsCount(),
@@ -230,9 +230,9 @@ static void onGotIP(const WiFiEventStationModeGotIP& e) {
   DEBUG("DHCP Got IP Address!");
 }
 
-static void onDHCPTimeout(void) {
-  DEBUG("DHCP Timeout");
-}
+//static void onDHCPTimeout(void) {
+//  DEBUG("DHCP Timeout");
+//}
 
 static void onStationModeConnected(const WiFiEventStationModeConnected& e) {
   DEBUG("StationModeConnected");

--- a/src/esp/main.cpp
+++ b/src/esp/main.cpp
@@ -59,7 +59,6 @@ KommandHandlerSKData skDataHandler(webServer);
 KommandHandlerWiFiConfiguration wiFiConfigurationHandler;
 ESPState espState;
 WiFiEventHandler onGotIPHandler;
-WiFiEventHandler onDhcpTimeoutHandler;
 WiFiEventHandler onStationModeConnectedHandler;
 WiFiEventHandler onStationModeDisconnectedHandler;
 
@@ -70,7 +69,6 @@ static void reportStatus(ESPState state, uint16_t dhcpClients = 0,
 static void configurationCallback(const WiFiConfiguration&);
 
 static void onGotIP(const WiFiEventStationModeGotIP&);
-//static void onDHCPTimeout(void);
 static void onStationModeConnected(const WiFiEventStationModeConnected&);
 static void onStationModeDisconnected(const WiFiEventStationModeDisconnected&);
 
@@ -95,7 +93,6 @@ void setup() {
   wiFiConfigurationHandler.setCallback(configurationCallback);
 
   onGotIPHandler = WiFi.onStationModeGotIP(onGotIP);
-//  onDhcpTimeoutHandler = WiFi.onStationModeDHCPTimeout(onDHCPTimeout);
   onStationModeConnectedHandler =
     WiFi.onStationModeConnected(onStationModeConnected);
   onStationModeDisconnectedHandler =
@@ -230,10 +227,6 @@ static void onGotIP(const WiFiEventStationModeGotIP& e) {
   DEBUG("DHCP Got IP Address!");
 }
 
-//static void onDHCPTimeout(void) {
-//  DEBUG("DHCP Timeout");
-//}
-
 static void onStationModeConnected(const WiFiEventStationModeConnected& e) {
   DEBUG("StationModeConnected");
 }
@@ -241,7 +234,6 @@ static void onStationModeDisconnected(const WiFiEventStationModeDisconnected&
 e) {
   DEBUG("StationModeDisconnected - reason=%i", e.reason);
 }
-
 
 static void reportStatus(ESPState state, uint16_t dhcpClients,
                          uint16_t tcpClients, uint16_t signalkClients,


### PR DESCRIPTION
Tried really hard to find the source of that crash in our code but I have not been able to run code on the ESP that does not crash when you connect to it via the network and send it data on the serial port.

So I am rolling back to ESP framework 2.3 which is stable.