### PR TITLE
Feature/platformio fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ cache: pip
 install:
     - pip install -U platformio cpp-coveralls
     - pip install -r src/sktool/requirements.txt
-    - sudo apt-get install emscripten -y
 
 script:
-    # This builds all the targets
-    - platformio run
+    # This builds all the targets compatible with travis
+    # we do not build sktooljs on travis at the moment
+    - platformio run -e host -e esp -e program-esp -e mfg -e sktool -e test
     # Run the few unit tests (C code running on computer)
     - make test
     # Run the sktool-test.py script to validate that SignalK output is valid and

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
     - sudo apt-get install emscripten -y
 
 script:
-    # This builds all the target
+    # This builds all the targets
     - platformio run
     # Run the few unit tests (C code running on computer)
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ cache: pip
 install:
     - pip install -U platformio cpp-coveralls
     - pip install -r src/sktool/requirements.txt
-    - apt-get install emscripten -y
+    - sudo apt-get install emscripten -y
 
 script:
     # This builds all the target

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,19 @@ script:
 
 after_success:
     - coveralls --exclude src/test --exclude /lib --exclude lib --exclude .piolibdeps
+
+deploy:
+  provider: releases
+  api_key:
+    secure: QYe/1yIJZbSe5uZfoCROTT7s+1Yhe0lY1Ww8Ia//yYMQOYjvkjY+UAHaZ7FN+X3MBHPcMQCEPxeG4Hmy7fvTTV2nIRPlkheirZqSYt7HYr9WdbA/N29F92o/EMT5nQgqfmOf9u61Hx5K3JLyBnLIilajOpnHgARJXgg7w8lC2hE57k9oO0PWlFLGrNZRa9xfHeHnrOVL90TW3sk6/YR6J5u+cg2ZMwFPs8PPCxw/cBDowvQ3JrXrrQwRxHiAnrTscYlHoFEidsAAnrL99GROiRgFEGYQhddilztQ/h52AUy9+QDxAlVgxV/hi1+AUOGeeSK4GQPugrfH1+3kTR4a6T/XdTBoydTQSUYTHU4PcKJwzoaEwOVGVr4lg0Fl5ZCktcPLlY+TBHfBfitPAaNujWTA5P/pUv3Vwdq5pX4xYfhqFKIqZohlDOYEhk0xtAYvlYB4teaLCGkPNjtBi+8e11FghdaSZ/G6vXCkvGeOPrSIcp9g4pwnpwwhMMJISdpnpxm5cSLZJBOAJybsYUIPjVtjfvAQ6e0GpvcQsePDFBz6qSFSvYIpgEBE8gOcNotWHyiHjCkV4aAm+mBFmJ5Ndfr6XMSK+uARWG98FRrGNN4HZJl3h7cRrd2f1cOIm9N7SWLIXmMwEMYyIq+X++ZCKqOMhFnw3THhFxZ+U5ACOQM=
+  file:
+    - ".pioenvs/host/firmware.elf"
+    - ".pioenvs/host/firmware.hex"
+    - ".pioenvs/esp/firmware.elf"
+    - ".pioenvs/esp/firmware.bin"
+    - ".pioenvs/sktool/program"
+  skip_cleanup: true
+  on:
+    repo: sarfata/kbox-firmware
+    branch: master
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ cache: pip
 install:
     - pip install -U platformio cpp-coveralls
     - pip install -r src/sktool/requirements.txt
+    - apt-get install emscripten -y
 
 script:
     # This builds all the target

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ ifeq ($(UNAME), Darwin)
 endif
 
 
-all: host esp mfg test sktool validation
+all:
+	platformio run
 
 clean:
 	platformio -f -c vim run --target clean

--- a/README.md
+++ b/README.md
@@ -193,8 +193,9 @@ been possible!**
 ## Changelog
 
  * 2018 07 06 - v1.3.2
-   * No changes to the code, just changes to the build configuration to improve
-     compatibility with Windows and address breaking changes in plaformio.
+   * Changes to the build configuration to improve compatibility with Windows 
+     and address breaking changes in plaformio.
+   * Fix some issues that prevented the tests and sktool from compiling on Windows.
    * Also added automatic builds on AppVeyor with Windows to hopefully detect
      Windows issues sooner in the future.
  * 2018 05 26 - v1.3.1

--- a/README.md
+++ b/README.md
@@ -192,14 +192,19 @@ been possible!**
 
 ## Changelog
 
+ * 2018 07 06 - v1.3.2
+   * No changes to the code, just changes to the build configuration to improve
+     compatibility with Windows and address breaking changes in plaformio.
+   * Also added automatic builds on AppVeyor with Windows to hopefully detect
+     Windows issues sooner in the future.
  * 2018 05 26 - v1.3.1
    * Fix bug which prevented WiFiRXError from being displayed on stats page.
    * Fix bug in `kbox.py` tool send wifi config command.
  * 2018 05 18 - v1.3.0
-   * New logfile format, compatible with SignalK server, saves NMEA messages, 
+   * New logfile format, compatible with SignalK server, saves NMEA messages,
      NMEA2000 messages and SignalK messages.
    * KBox will get the date from NMEA or NMEA2000 and display it on the screen.
-   * KBox will wait until it knows the current time to start logging (this can 
+   * KBox will wait until it knows the current time to start logging (this can
      be changed via configuration)
    * Log files are named after date and time of their creation
    * KBox will save in the logfile important system messages and some stats
@@ -216,7 +221,7 @@ been possible!**
            "logSignalKGeneratedFromNMEA2000": false,
            "logSignalKGeneratedByKBoxSensors": true
          },
-         
+
    * KBox will print version number and time on the "StatsPage"
    * StatsPage is the new default page
    * ![KBox v1.3.0](kbox-v1.3.0.png)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 install:
-    - cmd: SET PATH=%PATH%;C:\Python27\Scripts;
+    - cmd: SET PATH=%PATH%;C:\Python27\Scripts;C:\MinGW\bin
     - cmd: pip install -U platformio
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 install:
-    - cmd: SET PATH=%PATH%;C:\Python27\Scripts;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\bin
+    - cmd: SET PATH=%PATH%;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\
     - cmd: pip install -U platformio
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,7 @@
+install:
+    - cmd: SET PATH=%PATH%;C:\Python27\Scripts
+    - cmd: pip install -U platformio
+
+build_script:
+    - cmd: platformio run -e host
+    - cmd: platformio run -e esp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,5 +4,11 @@ install:
 
 build_script:
     - cmd: platformio run -e host
+    - cmd: platformio run -e program-esp
+    - cmd: platformio run -e mfg
     - cmd: platformio run -e esp
     - cmd: platformio run -e test
+    - cmd: platformio run -e sktool
+
+test_script:
+    - cmd: .pioenvs\test\program.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 install:
-    - cmd: SET PATH=%PATH%;C:\Python27\Scripts;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\bin
+    - cmd: SET PATH=%PATH%;C:\Python27\Scripts;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\bin
     - cmd: pip install -U platformio
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 install:
-    - cmd: SET PATH=%PATH%;C:\Python27\Scripts
+    - cmd: SET PATH=%PATH%;C:\Python27\Scripts;
     - cmd: pip install -U platformio
 
 build_script:
     - cmd: platformio run -e host
     - cmd: platformio run -e esp
+    - cmd: platformio run -e test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 install:
-    - cmd: SET PATH=%PATH%;C:\Python27\Scripts;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1
+    - cmd: SET PATH=%PATH%;C:\Python27\Scripts;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\bin
     - cmd: pip install -U platformio
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 install:
-    - cmd: SET PATH=%PATH%;C:\Python27\Scripts;C:\MinGW\bin
+    - cmd: SET PATH=%PATH%;C:\Python27\Scripts;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1
     - cmd: pip install -U platformio
 
 build_script:

--- a/lib/KBoxLogging/src/KBoxLoggerStream.cpp
+++ b/lib/KBoxLogging/src/KBoxLoggerStream.cpp
@@ -24,6 +24,8 @@
 
 #include "KBoxLoggerStream.h"
 
+#include <stdio.h>
+
 static int strrpos(const char *string, char c) {
   int index = -1;
   int i = 0;

--- a/platformio.ini
+++ b/platformio.ini
@@ -119,7 +119,7 @@ src_filter =
     +<common/comms/*>, +<common/nmea/*>, +<common/signalk/*>, +<common/time/*>, +<common/util/*>,
     +<host/config/*>,
     +<test/*>
-build_flags = -g -O0 --coverage -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -I src/test/teensyheaders -DKBOX_TESTS -DHAVE_STRLCPY -DHAVE_STRLCAT
+build_flags = -g -O0 --coverage -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -I src/test/teensyheaders -DKBOX_TESTS
 platform = native
 lib_deps =
   ${common.lib_deps_common}
@@ -130,7 +130,7 @@ lib_ignore = ${common.incompatibile_libs_native}
 
 [env:sktool]
 src_filter = +<sktool/*>, +<common/nmea/*>, +<common/signalk/*>, +<common/util/*>, +<test/teensy_compat.c>, +<test/arduinomock/*>
-build_flags = -g -O0 -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -Isrc/test/teensyheaders -DKBOX_TESTS -DHAVE_STRLCPY -DHAVE_STRLCAT
+build_flags = -g -O0 -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -Isrc/test/teensyheaders -DKBOX_TESTS
 platform = native
 lib_deps =
   ${common.lib_deps_common}
@@ -141,7 +141,7 @@ extra_scripts = tools/platformio_cfg_bsdstring.py
 
 [env:sktooljs]
 src_filter = +<sktool/*>, +<common/nmea/*>, +<common/signalk/*>, +<common/util/*>, +<test/teensy_compat.c>, +<test/arduinomock/*>
-build_flags = -g -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -Isrc/test/teensyheaders -DKBOX_TESTS -DHAVE_STRLCPY -DHAVE_STRLCAT
+build_flags = -g -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -Isrc/test/teensyheaders -DKBOX_TESTS
 platform = native
 lib_deps =
   ${common.lib_deps_common}

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,28 @@ lib_deps_teensy =
   https://github.com/sarfata/NMEA2000_Teensy#4661d8a
   https://github.com/greiman/SdFat#11d6d9c
   https://github.com/blackketter/ILI9341_t3#94ca23a
+incompatible_libs_teensy =
+  ESPAsyncTCP
+  ESP Async WebServer
+incompatible_libs_esp =
+  NMEA2000-Teensy
+  FlexCAN_Library
+  Time
+  Adafruit INA219
+  Adafruit BMP280 Library
+  Adafruit BNO055
+  KBoxHardware
+  ILI9341_t3
+  ILI9341_fonts
+  fonts
+  Teensy_ADC
+  Encoder
+  i2c_t3
+  SdFat
+incompatibile_libs_native =
+  ${common.incompatible_libs_teensy}
+  ${common.incompatible_libs_esp}
+  Adafruit NeoPixel
 
 [env:host]
 src_filter = +<common/*>,+<host/*>
@@ -35,6 +57,7 @@ board = teensy31
 lib_deps =
   ${common.lib_deps_common}
   ${common.lib_deps_teensy}
+lib_ignore = ${common.incompatible_libs_teensy}
 extra_scripts = tools/platformio_cfg_gitversion.py
 # uncomment to get seatalk support
 #build_flags = ${common.build_flags} -DSERIAL_9BIT_SUPPORT -DSEATALK
@@ -56,6 +79,7 @@ lib_ldf_mode = deep
 lib_deps =
   ${common.lib_deps_common}
   ${common.lib_deps_teensy}
+lib_ignore = ${common.incompatible_libs_teensy}
 
 [env:esp]
 src_filter = +<common/*>,+<esp/*>
@@ -68,10 +92,10 @@ platform=https://github.com/platformio/platform-espressif8266.git#feature/stage
 framework = arduino
 board = esp_wroom_02
 extra_scripts =
-  tools/platformio_cfg_esp.py
+#  tools/platformio_cfg_esp.py
   tools/platformio_cfg_gitversion.py
 lib_ldf_mode = deep
-lib_ignore = NMEA2000-Teensy, FlexCAN_Library, Time
+lib_ignore = ${common.incompatible_libs_esp}
 lib_deps =
   ${common.lib_deps_common}
   Adafruit NeoPixel
@@ -88,40 +112,40 @@ board = teensy31
 lib_deps =
   ${common.lib_deps_common}
   ${common.lib_deps_teensy}
+lib_ignore = ${common.incompatible_libs_teensy}
 
 [env:test]
 src_filter =
     +<common/comms/*>, +<common/nmea/*>, +<common/signalk/*>, +<common/time/*>, +<common/util/*>,
     +<host/config/*>,
     +<test/*>
-build_flags = -g -O0 --coverage -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -I src/test/teensyheaders -DKBOX_TESTS
+build_flags = -g -O0 --coverage -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -I src/test/teensyheaders -DKBOX_TESTS -DHAVE_STRLCPY -DHAVE_STRLCAT
 platform = native
 lib_deps =
   ${common.lib_deps_common}
-lib_ignore = elapsedMillis, NMEA2000_teensy, Time
 # Helps platformio who otherwise chokes on ArduinoJson header only style
 lib_archive = false
 extra_scripts = tools/platformio_cfg_test.py, tools/platformio_cfg_bsdstring.py
-
+lib_ignore = ${common.incompatibile_libs_native}
 
 [env:sktool]
 src_filter = +<sktool/*>, +<common/nmea/*>, +<common/signalk/*>, +<common/util/*>, +<test/teensy_compat.c>, +<test/arduinomock/*>
-build_flags = -g -O0 -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -Isrc/test/teensyheaders -DKBOX_TESTS
+build_flags = -g -O0 -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -Isrc/test/teensyheaders -DKBOX_TESTS -DHAVE_STRLCPY -DHAVE_STRLCAT
 platform = native
 lib_deps =
   ${common.lib_deps_common}
-lib_ignore = elapsedMillis, NMEA2000_teensy, Time
+lib_ignore = ${common.incompatibile_libs_native}
 # Helps platformio who otherwise chokes on ArduinoJson header only style
 lib_archive = false
 extra_scripts = tools/platformio_cfg_bsdstring.py
 
 [env:sktooljs]
 src_filter = +<sktool/*>, +<common/nmea/*>, +<common/signalk/*>, +<common/util/*>, +<test/teensy_compat.c>, +<test/arduinomock/*>
-build_flags = -g -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -Isrc/test/teensyheaders -DKBOX_TESTS
+build_flags = -g -Wall -Werror -std=c++11 -Isrc/common -Isrc/test/arduinomock -Isrc/test/teensyheaders -DKBOX_TESTS -DHAVE_STRLCPY -DHAVE_STRLCAT
 platform = native
 lib_deps =
   ${common.lib_deps_common}
-lib_ignore = elapsedMillis, NMEA2000_teensy, Time
+lib_ignore = ${common.incompatibile_libs_native}
 # Helps platformio who otherwise chokes on ArduinoJson header only style
 lib_archive = false
 extra_scripts =
@@ -145,6 +169,7 @@ board = teensy36
 lib_deps =
   ${common.lib_deps_common}
   ${common.lib_deps_teensy}
+lib_ignore = ${common.incompatible_libs_teensy}
 extra_scripts = tools/platformio_cfg_gitversion.py
 
 [env:program-esp-teensy36]
@@ -157,6 +182,7 @@ lib_ldf_mode = deep
 lib_deps =
   ${common.lib_deps_common}
   ${common.lib_deps_teensy}
+lib_ignore = ${common.incompatible_libs_teensy}
 
 [env:mfg-teensy36]
 src_filter = +<common/*>, +<mfg/*>, +<host/drivers/ILI9341GC.cpp>
@@ -167,3 +193,4 @@ board = teensy36
 lib_deps =
   ${common.lib_deps_common}
   ${common.lib_deps_teensy}
+lib_ignore = ${common.incompatible_libs_teensy}

--- a/platformio.ini
+++ b/platformio.ini
@@ -92,7 +92,7 @@ platform=https://github.com/platformio/platform-espressif8266.git#feature/stage
 framework = arduino
 board = esp_wroom_02
 extra_scripts =
-#  tools/platformio_cfg_esp.py
+  tools/platformio_cfg_esp.py
   tools/platformio_cfg_gitversion.py
 lib_ldf_mode = deep
 lib_ignore = ${common.incompatible_libs_esp}

--- a/src/common/signalk/SKUnits.h
+++ b/src/common/signalk/SKUnits.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cmath>
 #ifndef M_PI
   #define M_PI 3.14159265358979323846
 #endif

--- a/src/common/signalk/SKUnits.h
+++ b/src/common/signalk/SKUnits.h
@@ -24,7 +24,9 @@
 
 #pragma once
 
-#include <math.h>
+#ifndef M_PI
+  #define M_PI 3.14159265358979323846
+#endif
 
 #define SKKnotToMs(x) (x) * 1852 / 3600
 #define SKStatuteMphToMs(x) (x) * 1609.344 / 3600

--- a/src/common/signalk/SKUnits.h
+++ b/src/common/signalk/SKUnits.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <cmath>
+#include <math.h>
 #ifndef M_PI
   #define M_PI 3.14159265358979323846
 #endif

--- a/src/sktool/main.cpp
+++ b/src/sktool/main.cpp
@@ -30,6 +30,7 @@
 
 #include <iostream>
 #include <string>
+#include <ctime>
 #include <WString.h>
 #include <ArduinoJson.h>
 #include <Seasmart.h>

--- a/src/test/signalk/SKNMEAParserTest.cpp
+++ b/src/test/signalk/SKNMEAParserTest.cpp
@@ -105,7 +105,7 @@ TEST_CASE("SKNMEAParser: MWV") {
     // Unit S seems to be knots but I cannot find a real source here.
     const SKUpdate& update = p.parse(SKSourceInputNMEA0183_1, "$WIMWV,168.1,R,5.6,K,A*2B", SKTime(42));
 
-    CHECK( update.getEnvironmentWindSpeedApparent() == SKKmphToMs(5.6) );
+    CHECK( update.getEnvironmentWindSpeedApparent() == Approx(SKKmphToMs(5.6)) );
   }
   SECTION("MWV with invalid sensor status (V)") {
     const SKUpdate& update = p.parse(SKSourceInputNMEA0183_1, "$WIMWV,168.1,R,5.6,S,V*24", SKTime(42));

--- a/src/test/teensyheaders/avr_functions.h
+++ b/src/test/teensyheaders/avr_functions.h
@@ -96,10 +96,10 @@ char * ultoa(unsigned long val, char *buf, int radix);
 char * ltoa(long val, char *buf, int radix);
 
 #if defined(KBOX_TESTS) || (defined(_NEWLIB_VERSION) && (__NEWLIB__ < 2 || __NEWLIB__ == 2 && __NEWLIB_MINOR__ < 2))
-static inline char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
-static inline char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
-static inline char * itoa(int val, char *buf, int radix) __attribute__((always_inline, unused));
-static inline char * itoa(int val, char *buf, int radix) { return ltoa(val, buf, radix); }
+inline char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
+inline char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
+inline char * itoa(int val, char *buf, int radix) __attribute__((always_inline, unused));
+inline char * itoa(int val, char *buf, int radix) { return ltoa(val, buf, radix); }
 #endif
 
 char * dtostrf(float val, int width, unsigned int precision, char *buf);

--- a/tools/platformio_cfg_bsdstring.py
+++ b/tools/platformio_cfg_bsdstring.py
@@ -8,4 +8,3 @@ try:
     print("Compiler {} has STRLCPY".format(projenv['CC']))
 except Exception as e:
     print("Compiler {} *does not* have STRLCPY\n{}".format(projenv['CC'], e))
-    raise e

--- a/tools/platformio_cfg_bsdstring.py
+++ b/tools/platformio_cfg_bsdstring.py
@@ -3,6 +3,12 @@ import subprocess
 from sys import platform
 
 try:
+    version = subprocess.check_output([projenv["CC"], "--version"], stderr=subprocess.STDOUT)
+    print("Compiler {} - {}".format(projenv['CC'], version))
+except Exception as e:
+    raise Exception("Unable to get compiler version ({} --version)".format(projenv['CC']), e)
+
+try:
     if platform == 'win32':
         subprocess.check_call('echo unsigned long strlcat(char *dst, const char *src, unsigned long dsize); int main(){{ char *a = "hello "; char *b = "world"; strlcat(a, b, 5); }} |{} -o test -xc -'.format(projenv['CC']), shell = True)
     else:

--- a/tools/platformio_cfg_bsdstring.py
+++ b/tools/platformio_cfg_bsdstring.py
@@ -1,11 +1,12 @@
 Import("projenv")
 import subprocess
+from sys import platform
 
 try:
-    if platform == 'windows':
-        subprocess.check_call('echo \'unsigned long strlcat(char *dst, const char *src, unsigned long dsize); int main(){{ char *a = "hello "; char *b = "world"; strlcat(a, b, 5); }}\' |{} -o test -xc -'.format(projenv['CC']), shell = True)
-    else:
+    if platform == 'win32':
         subprocess.check_call('echo unsigned long strlcat(char *dst, const char *src, unsigned long dsize); int main(){{ char *a = "hello "; char *b = "world"; strlcat(a, b, 5); }} |{} -o test -xc -'.format(projenv['CC']), shell = True)
+    else:
+        subprocess.check_call('echo \'unsigned long strlcat(char *dst, const char *src, unsigned long dsize); int main(){{ char *a = "hello "; char *b = "world"; strlcat(a, b, 5); }}\' |{} -o test -xc -'.format(projenv['CC']), shell = True)
     # add the flags if our test program ran without errors
     projenv.Append(CCFLAGS=["-DHAVE_STRLCPY", "-DHAVE_STRLCAT"])
     print("Compiler {} has STRLCPY".format(projenv['CC']))

--- a/tools/platformio_cfg_bsdstring.py
+++ b/tools/platformio_cfg_bsdstring.py
@@ -2,7 +2,10 @@ Import("projenv")
 import subprocess
 
 try:
-    subprocess.check_call('echo \'unsigned long strlcat(char *dst, const char *src, unsigned long dsize); int main(){{ char *a = "hello "; char *b = "world"; strlcat(a, b, 5); }}\' |{} -o test -xc -'.format(projenv['CC']), shell = True)
+    if platform == 'windows':
+        subprocess.check_call('echo \'unsigned long strlcat(char *dst, const char *src, unsigned long dsize); int main(){{ char *a = "hello "; char *b = "world"; strlcat(a, b, 5); }}\' |{} -o test -xc -'.format(projenv['CC']), shell = True)
+    else:
+        subprocess.check_call('echo unsigned long strlcat(char *dst, const char *src, unsigned long dsize); int main(){{ char *a = "hello "; char *b = "world"; strlcat(a, b, 5); }} |{} -o test -xc -'.format(projenv['CC']), shell = True)
     # add the flags if our test program ran without errors
     projenv.Append(CCFLAGS=["-DHAVE_STRLCPY", "-DHAVE_STRLCAT"])
     print("Compiler {} has STRLCPY".format(projenv['CC']))

--- a/tools/platformio_cfg_bsdstring.py
+++ b/tools/platformio_cfg_bsdstring.py
@@ -2,8 +2,10 @@ Import("projenv")
 import subprocess
 
 try:
-    subprocess.check_call('echo \'unsigned long strlcat(char *dst, const char *src, unsigned long dsize); int main(){ char *a = "hello "; char *b = "world"; strlcat(a, b, 5); }\' |gcc -o test -xc -', shell = True)
+    subprocess.check_call('echo \'unsigned long strlcat(char *dst, const char *src, unsigned long dsize); int main(){{ char *a = "hello "; char *b = "world"; strlcat(a, b, 5); }}\' |{} -o test -xc -'.format(projenv['CC']), shell = True)
     # add the flags if our test program ran without errors
     projenv.Append(CCFLAGS=["-DHAVE_STRLCPY", "-DHAVE_STRLCAT"])
+    print("Compiler {} has STRLCPY".format(projenv['CC']))
 except Exception as e:
-    pass
+    print("Compiler {} *does not* have STRLCPY\n{}".format(projenv['CC'], e))
+    raise e

--- a/tools/platformio_cfg_bsdstring.py
+++ b/tools/platformio_cfg_bsdstring.py
@@ -1,8 +1,9 @@
-from SCons.Script import DefaultEnvironment
-from sys import platform
+Import("projenv")
+import subprocess
 
-env = DefaultEnvironment()
-
-if platform == "darwin":
-    env.Append(CCFLAGS=["-DHAVE_STRLCPY", "-DHAVE_STRLCAT"])
-
+try:
+    subprocess.check_call('echo \'unsigned long strlcat(char *dst, const char *src, unsigned long dsize); int main(){ char *a = "hello "; char *b = "world"; strlcat(a, b, 5); }\' |gcc -o test -xc -', shell = True)
+    # add the flags if our test program ran without errors
+    projenv.Append(CCFLAGS=["-DHAVE_STRLCPY", "-DHAVE_STRLCAT"])
+except Exception as e:
+    pass

--- a/tools/platformio_cfg_emscripten.py
+++ b/tools/platformio_cfg_emscripten.py
@@ -1,5 +1,4 @@
 Import("env")
-from sys import platform
 
 env.Replace(
     PROGNAME="sktool.js",

--- a/tools/platformio_cfg_emscripten.py
+++ b/tools/platformio_cfg_emscripten.py
@@ -1,7 +1,5 @@
-from SCons.Script import DefaultEnvironment
+Import("env")
 from sys import platform
-
-env = DefaultEnvironment()
 
 env.Replace(
     PROGNAME="sktool.js",

--- a/tools/platformio_cfg_emscripten.py
+++ b/tools/platformio_cfg_emscripten.py
@@ -1,0 +1,12 @@
+from SCons.Script import DefaultEnvironment
+from sys import platform
+
+env = DefaultEnvironment()
+
+env.Replace(
+    PROGNAME="sktool.js",
+    PROGSUFFIX=".js",
+    CC="emcc",
+    CXX="em++",
+    LINKFLAGS="-s EXPORTED_FUNCTIONS='[\"_sktoolConvert\"]' -s EXTRA_EXPORTED_RUNTIME_METHODS='[\"ccall\", \"cwrap\"]'"
+)

--- a/tools/platformio_cfg_gitversion.py
+++ b/tools/platformio_cfg_gitversion.py
@@ -1,6 +1,5 @@
 Import("projenv")
 import subprocess
-from datetime import datetime
 
 version = "git-cmd-not-available"
 

--- a/tools/platformio_cfg_gitversion.py
+++ b/tools/platformio_cfg_gitversion.py
@@ -1,4 +1,4 @@
-Import("env")
+Import("projenv")
 import subprocess
 from datetime import datetime
 
@@ -9,4 +9,4 @@ try:
 except:
     pass
 
-env.Append(CCFLAGS=["-DKBOX_VERSION=\"\\\"{}\\\"\"".format(version)])
+projenv.Append(CCFLAGS=["-DKBOX_VERSION=\"\\\"{}\\\"\"".format(version)])

--- a/tools/platformio_cfg_test.py
+++ b/tools/platformio_cfg_test.py
@@ -1,10 +1,7 @@
-from SCons.Script import DefaultEnvironment
-
-env = DefaultEnvironment()
+Import("env")
 
 env.Append(
         LINKFLAGS=[
             "--coverage"
             ]
         )
-


### PR DESCRIPTION
This addresses two separate "issues" in the latest platformio:
 - CCFLAGS are now defined separately for frameworks and project files
platformio/platformio-core#1719
 - platformio builds all libraries for all platforms if they are not
excluded
platformio/platformio-core#1696