### PR TITLE
Feature/fix esp upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,16 +41,23 @@ script:
 after_success:
     - coveralls --exclude src/test --exclude /lib --exclude lib --exclude .piolibdeps
 
+before_deploy:
+    - mv .pioenvs/host/firmware.elf ./kbox-firmware-$TRAVIS_TAG.elf
+    - mv .pioenvs/host/firmware.hex ./kbox-firmware-$TRAVIS_TAG.hex
+    - mv .pioenvs/esp/firmware.elf ./kbox-wifi-$TRAVIS_TAG.elf
+    - mv .pioenvs/esp/firmware.bin ./kbox-wifi-$TRAVIS_TAG.bin
+    - mv .pioenvs/sktool/program ./sktool-$TRAVIS_TAG
+
 deploy:
   provider: releases
   api_key:
     secure: QYe/1yIJZbSe5uZfoCROTT7s+1Yhe0lY1Ww8Ia//yYMQOYjvkjY+UAHaZ7FN+X3MBHPcMQCEPxeG4Hmy7fvTTV2nIRPlkheirZqSYt7HYr9WdbA/N29F92o/EMT5nQgqfmOf9u61Hx5K3JLyBnLIilajOpnHgARJXgg7w8lC2hE57k9oO0PWlFLGrNZRa9xfHeHnrOVL90TW3sk6/YR6J5u+cg2ZMwFPs8PPCxw/cBDowvQ3JrXrrQwRxHiAnrTscYlHoFEidsAAnrL99GROiRgFEGYQhddilztQ/h52AUy9+QDxAlVgxV/hi1+AUOGeeSK4GQPugrfH1+3kTR4a6T/XdTBoydTQSUYTHU4PcKJwzoaEwOVGVr4lg0Fl5ZCktcPLlY+TBHfBfitPAaNujWTA5P/pUv3Vwdq5pX4xYfhqFKIqZohlDOYEhk0xtAYvlYB4teaLCGkPNjtBi+8e11FghdaSZ/G6vXCkvGeOPrSIcp9g4pwnpwwhMMJISdpnpxm5cSLZJBOAJybsYUIPjVtjfvAQ6e0GpvcQsePDFBz6qSFSvYIpgEBE8gOcNotWHyiHjCkV4aAm+mBFmJ5Ndfr6XMSK+uARWG98FRrGNN4HZJl3h7cRrd2f1cOIm9N7SWLIXmMwEMYyIq+X++ZCKqOMhFnw3THhFxZ+U5ACOQM=
   file:
-    - ".pioenvs/host/firmware.elf"
-    - ".pioenvs/host/firmware.hex"
-    - ".pioenvs/esp/firmware.elf"
-    - ".pioenvs/esp/firmware.bin"
-    - ".pioenvs/sktool/program"
+    - ./kbox-firmware-$TRAVIS_TAG.elf
+    - ./kbox-firmware-$TRAVIS_TAG.hex
+    - ./kbox-wifi-$TRAVIS_TAG.elf
+    - ./kbox-wifi-$TRAVIS_TAG.bin
+    - ./sktool-$TRAVIS_TAG
   skip_cleanup: true
   on:
     repo: sarfata/kbox-firmware

--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ been possible!**
             platform run -e host -t upload
             platformio run -e esp -t upload
 
+   * Change default esp upload speed to 921600 because 2000000 does not seem well
+     supported on Windows.
+   * Changed the 'end of programming' detection method to more reliably detect when
+     we are done programming and reboot KBox.
+   * Tested the official ESP uploader on Windows and OS X. Comment out the line 
+     `tools/platformio_cfg_esp.py` in `platformio.ini` to use it.
+     It will be a little bit slower but might work better for some people.
+
  * 2018 07 06 - v1.3.2
    * Changes to the build configuration to improve compatibility with Windows 
      and address breaking changes in plaformio.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ been possible!**
 
 ## Changelog
 
+ * 2018 07 06 - v1.3.3
+   * Fix a bug which forced us to use `program-esp` to update the wifi module.
+     It is now possible again to just use the following commands to update KBox:
+     
+            platform run -e host -t upload
+            platformio run -e esp -t upload
+
  * 2018 07 06 - v1.3.2
    * Changes to the build configuration to improve compatibility with Windows 
      and address breaking changes in plaformio.

--- a/lib/KBoxHardware/src/KBoxHardware.cpp
+++ b/lib/KBoxHardware/src/KBoxHardware.cpp
@@ -106,9 +106,6 @@ void KBoxHardware::setBacklight(BacklightIntensity intensity) {
 }
 
 void KBoxHardware::espInit() {
-  WiFiSerial.begin(1000000);
-  WiFiSerial.setTimeout(0);
-
   digitalWrite(wifi_enable, 0);
   digitalWrite(wifi_rst, 0);
 
@@ -129,6 +126,9 @@ void KBoxHardware::espInit() {
 }
 
 void KBoxHardware::espRebootInFlasher() {
+  WiFiSerial.begin(115200);
+  WiFiSerial.setTimeout(0);
+
   digitalWrite(wifi_enable, 0);
   digitalWrite(wifi_rst, 0);
   digitalWrite(wifi_program, 0);
@@ -141,6 +141,9 @@ void KBoxHardware::espRebootInFlasher() {
 }
 
 void KBoxHardware::espRebootInProgram() {
+  WiFiSerial.begin(1000000);
+  WiFiSerial.setTimeout(0);
+
   digitalWrite(wifi_enable, 0);
   digitalWrite(wifi_rst, 0);
   digitalWrite(wifi_program, 1);

--- a/platformio.ini
+++ b/platformio.ini
@@ -91,6 +91,7 @@ build_flags = -Wall -Werror -fno-strict-aliasing
 platform=https://github.com/platformio/platform-espressif8266.git#feature/stage
 framework = arduino
 board = esp_wroom_02
+upload_speed = 921600
 extra_scripts =
   tools/platformio_cfg_esp.py
   tools/platformio_cfg_gitversion.py

--- a/src/host/esp-programmer/ESPProgrammer.cpp
+++ b/src/host/esp-programmer/ESPProgrammer.cpp
@@ -210,7 +210,7 @@ void ESPProgrammer::updateColors() {
     wheelIndex++;
   }
 
-  // Intensity of color will be proportial to how recent the last byte received was
+  // Intensity of color will be proportional to how recent the last byte received was
   // After 500ms, the color will be 0
   int dim = 0;
   if (timeSinceLastByte < 500) {

--- a/src/host/esp-programmer/ESPProgrammer.cpp
+++ b/src/host/esp-programmer/ESPProgrammer.cpp
@@ -121,7 +121,6 @@ void ESPProgrammer::loopByteMode() {
     if (espSerial.available()) {
       int read = espSerial.readBytes(buffer, min(bootloaderMtu, espSerial.available()));
       computerSerial.write(buffer, read);
-      timeSinceLastByte = 0;
     }
   }
 }
@@ -165,7 +164,6 @@ void ESPProgrammer::loopFrameMode() {
     size_t len = espConnection.readFrame(buffer, bootloaderMtu);
     debugFrame("ESP", buffer, len);
     computerConnection.writeFrame(buffer, len);
-    timeSinceLastByte = 0;
   }
 }
 

--- a/src/host/services/USBService.cpp
+++ b/src/host/services/USBService.cpp
@@ -74,10 +74,10 @@ void USBService::loop() {
     _state = ConnectedDebug;
   }
 
-  /* Switching serial port to 230400 on computer signals that the host
+  /* Switching serial port to 230400 (or 921600) on computer signals that the host
    * wants to go into ESP Programming mode.
    */
-  if (Serial.baud() == 230400) {
+  if (Serial.baud() == 230400 || Serial.baud() == 921600) {
     _state = ConnectedESPProgramming;
   }
 

--- a/src/host/services/USBService.cpp
+++ b/src/host/services/USBService.cpp
@@ -158,10 +158,19 @@ void USBService::loopConnectedESPProgramming() {
   ESPProgrammerDelegateImpl delegate;
   ESPProgrammer programmer(KBox.getNeopixels(), Serial, Serial1, delegate);
 
+#if DEBUGGING_ESP_UPLOAD
+  // Redirect all logs to NMEA2 at 1Mbit/s.
+  NMEA2_SERIAL.begin(1000000);
+  KBoxLogging.setLogger(new KBoxLoggerStream(NMEA2_SERIAL));
+#endif
+  DEBUG("Switching to ESP Programming mode");
+
   while (programmer.getState() != ESPProgrammer::ProgrammerState::Done) {
     programmer.loop();
+    KBox.watchdogRefresh();
   }
-  DEBUG("Exiting programmer mode");
+
+  DEBUG("Exiting programmer mode"); delay(100);
   KBox.rebootKBox();
 }
 

--- a/tools/platformio_cfg_esp.py
+++ b/tools/platformio_cfg_esp.py
@@ -6,7 +6,7 @@ LOCAL_UPLOADER=os.path.join("$PROJECT_DIR","tools/esptool.py")
 env.Replace(
     LOCAL_UPLOADERFLAGS=[
         "-p", "$UPLOAD_PORT",
-        "-b", "2000000",
+        "-b", "$UPLOAD_SPEED",
         "write_flash", "--flash_mode", "dio", "--flash_size", "16m",
     ],
    UPLOADER=LOCAL_UPLOADER,


### PR DESCRIPTION
* 2018 07 06 - v1.3.3
   * Fix a bug which forced us to use `program-esp` to update the wifi module.
     It is now possible again to just use the following commands to update KBox:
     
            platform run -e host -t upload
            platformio run -e esp -t upload

   * Change default esp upload speed to 921600 because 2000000 does not seem well
     supported on Windows.
   * Changed the 'end of programming' detection method to more reliably detect when
     we are done programming and reboot KBox.
   * Tested the official ESP uploader on Windows and OS X. Comment out the line 
     `tools/platformio_cfg_esp.py` in `platformio.ini` to use it.
     It will be a little bit slower but might work better for some people.