### PR TITLE
Release v1.3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ CMakeListsPrivate.txt
 # CLion
 cmake-build-debug
 # User-specific stuff
+.idea/vcs.xml
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Because KBox is open-source, you can do a lot more things with it:
 
 ### Current software status
 
-As of December 2017, the KBox firmware:
+As of September 2018, the KBox firmware:
 
  - General functionality
    - Creates a new WiFi network (KBox) or can join an existing network (via simple
@@ -192,6 +192,18 @@ been possible!**
 
 ## Changelog
 
+ * 2018 09 07 - v1.3.6
+   * Force ESP board definition to generic module w 1MB flash to avoid build
+     error.
+   * Upgrade ESP platform to 1.8.0 to use ESP8266 framework 2.4.2 which improves
+     stability of the WiFi modules and seems to fix a number of connection
+     issues for other people. Hopefully will also improve KBox wifi stability.
+   * Add HTTP CORS header on `/signalk`. This makes KBox compatible with the
+     amazing [Kip](https://github.com/mxtommy/Kip) to display your boat data in
+     a browser.
+   * Fixed a typo in the reboot reasons.
+   * Add missing dependency `pyserial` in the list of dependencies for
+     `kbox.py`.
  * 2018 07 26 - v1.3.5
    * Fix a bug that would cause KBox to crash on NMEA sentences without a checksum
    * Fix a bug where RMC sentence without a date would crash KBox

--- a/lib/KBoxHardware/src/KBoxHardware.cpp
+++ b/lib/KBoxHardware/src/KBoxHardware.cpp
@@ -284,7 +284,7 @@ String KBoxHardware::rebootReason() {
     return "Loss of Lock in PLL Reset";
   if (RCM_SRS0 & RCM_SRS0_LVD)
     return "Low-voltage Detect Reset";
-  return "unknwon reset";
+  return "unknown reset reason";
 }
 
 void watchdog_isr() {

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,7 +52,7 @@ build_flags =
     -DSERIAL1_RX_BUFFER_SIZE=512 -DSERIAL1_TX_BUFFER_SIZE=512
     -DSERIAL2_RX_BUFFER_SIZE=256 -DSERIAL2_TX_BUFFER_SIZE=256
     -DSERIAL3_RX_BUFFER_SIZE=256 -DSERIAL3_TX_BUFFER_SIZE=256
-platform = teensy
+platform = teensy@3.4.0
 framework = arduino
 board = teensy31
 lib_deps =
@@ -73,7 +73,7 @@ extra_scripts = tools/platformio_cfg_gitversion.py
 [env:program-esp]
 src_filter = +<common/*>, +<program-esp/*>, +<host/esp-programmer/>
 build_flags = ${common.build_flags} -Isrc/common
-platform  = teensy
+platform  = teensy@3.4.0
 framework = arduino
 board = teensy31
 lib_ldf_mode = deep
@@ -88,10 +88,9 @@ src_filter = +<common/*>,+<esp/*>
 build_flags = -Wall -Werror -fno-strict-aliasing
     -Isrc/common -Isrc/esp
     -DHAVE_STRLCPY -DHAVE_STRLCAT
-#platform=espressif8266
-platform=https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform=espressif8266@1.8.0
 framework = arduino
-board = esp_wroom_02
+board = esp01_1m
 upload_speed = 921600
 extra_scripts =
   tools/platformio_cfg_esp.py
@@ -108,7 +107,7 @@ lib_deps =
 [env:mfg]
 src_filter = +<common/*>, +<mfg/*>, +<host/drivers/ILI9341GC.cpp>
 build_flags = ${common.build_flags} -Isrc/common
-platform = teensy
+platform = teensy@3.4.0
 framework = arduino
 board = teensy31
 lib_deps =
@@ -165,7 +164,7 @@ build_flags =
     -DSERIAL3_RX_BUFFER_SIZE=256 -DSERIAL3_TX_BUFFER_SIZE=256
     -DSERIAL4_RX_BUFFER_SIZE=256 -DSERIAL4_TX_BUFFER_SIZE=256
     -DSERIAL5_RX_BUFFER_SIZE=256 -DSERIAL5_TX_BUFFER_SIZE=256
-platform = teensy
+platform = teensy@3.4.0
 framework = arduino
 board = teensy36
 lib_deps =
@@ -177,7 +176,7 @@ extra_scripts = tools/platformio_cfg_gitversion.py
 [env:program-esp-teensy36]
 src_filter = +<common/*>, +<program-esp/*>, +<host/esp-programmer/>
 build_flags = ${common.build_flags} -Isrc/common
-platform  = teensy
+platform  = teensy@3.4.0
 framework = arduino
 board = teensy36
 lib_ldf_mode = deep
@@ -189,7 +188,7 @@ lib_ignore = ${common.incompatible_libs_teensy}
 [env:mfg-teensy36]
 src_filter = +<common/*>, +<mfg/*>, +<host/drivers/ILI9341GC.cpp>
 build_flags = ${common.build_flags} -Isrc/common
-platform = teensy
+platform = teensy@3.4.0
 framework = arduino
 board = teensy36
 lib_deps =

--- a/src/esp/net/KBoxWebServer.cpp
+++ b/src/esp/net/KBoxWebServer.cpp
@@ -158,6 +158,7 @@ void handleRequestSignalK(AsyncWebServerRequest *request) {
     serverInfo["version"] = KBOX_VERSION;
 
     root.printTo(*response);
+    response->addHeader("Access-Control-Allow-Origin","*");
     request->send(response);
   }
   else {

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,3 @@
 termcolor
 pypng
+pyserial


### PR DESCRIPTION
* 2018 09 07 - v1.3.6
   * Force ESP board definition to generic module w 1MB flash to avoid build
     error.
   * Upgrade ESP platform to 1.8.0 to use ESP8266 framework 2.4.2 which improves
     stability of the WiFi modules and seems to fix a number of connection
     issues for other people. Hopefully will also improve KBox wifi stability.
   * Add HTTP CORS header on `/signalk`. This makes KBox compatible with the
     amazing [Kip](https://github.com/mxtommy/Kip) to display your boat data in
     a browser.
   * Fixed a typo in the reboot reasons.
   * Add missing dependency `pyserial` in the list of dependencies for
     `kbox.py`.